### PR TITLE
Fix API key retrieval

### DIFF
--- a/extension/config.js
+++ b/extension/config.js
@@ -17,7 +17,7 @@ const DEFAULT_PROMPT = `You are an expert code reviewer. Your task is to analyze
  */
 export async function loadConfig() {
   try {
-    const settings = await chrome.storage.local.get();
+    const settings = await chrome.storage.sync.get();
 
     if (!settings.githubToken || !settings.openAIApiKey) {
       return {

--- a/extension/config.js
+++ b/extension/config.js
@@ -15,9 +15,11 @@ const DEFAULT_PROMPT = `You are an expert code reviewer. Your task is to analyze
  * Retrieves the application configuration from Chrome local storage, applying default values for optional settings and validating the presence of required API keys.
  * @returns {Promise<AppConfig>} Resolves to the configuration object, or an error message if required keys are missing or loading fails.
  */
+import { loadSettings } from "./settings.js";
+
 export async function loadConfig() {
   try {
-    const settings = await chrome.storage.sync.get();
+    const settings = await loadSettings();
 
     if (!settings.githubToken || !settings.openAIApiKey) {
       return {

--- a/extension/openaiApi.js
+++ b/extension/openaiApi.js
@@ -10,14 +10,11 @@ const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
  * @returns {Promise<{comments: Array<{line: number, body: string}>}>} An object containing an array of code review comments, or an empty array if none are found.
  * @throws {Error} If authentication fails, the API response is invalid, or the returned JSON is malformed.
  */
-async function getStoredApiKey() {
-  const result = await chrome.storage.sync.get("openAIApiKey");
-  return result.openAIApiKey || null;
-}
+import { loadSettings } from "./settings.js";
 
 export async function getReviewForPatch(patch, config = {}) {
-  const storedKey = await getStoredApiKey();
-  const openAIApiKey = config.openAIApiKey || storedKey;
+  const settings = await loadSettings();
+  const openAIApiKey = config.openAIApiKey || settings.openAIApiKey;
   const { openAIModel, systemPrompt } = config;
 
   if (!openAIApiKey) {

--- a/extension/openaiApi.js
+++ b/extension/openaiApi.js
@@ -10,8 +10,21 @@ const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
  * @returns {Promise<{comments: Array<{line: number, body: string}>}>} An object containing an array of code review comments, or an empty array if none are found.
  * @throws {Error} If authentication fails, the API response is invalid, or the returned JSON is malformed.
  */
-export async function getReviewForPatch(patch, config) {
-  const { openAIApiKey, openAIModel, systemPrompt } = config;
+async function getStoredApiKey() {
+  const result = await chrome.storage.sync.get("openAIApiKey");
+  return result.openAIApiKey || null;
+}
+
+export async function getReviewForPatch(patch, config = {}) {
+  const storedKey = await getStoredApiKey();
+  const openAIApiKey = config.openAIApiKey || storedKey;
+  const { openAIModel, systemPrompt } = config;
+
+  if (!openAIApiKey) {
+    throw new Error(
+      "OpenAI API key not found. Please add it in the options page.",
+    );
+  }
 
   const response = await fetch(OPENAI_API_URL, {
     method: "POST",

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,5 +1,10 @@
 // extension/options.js
 
+import {
+  loadSettings as getStoredSettings,
+  saveSettings as persistSettings,
+} from "./settings.js";
+
 const saveButton = document.getElementById("save-settings");
 const githubTokenInput = document.getElementById("githubToken");
 const openAIApiKeyInput = document.getElementById("openAIApiKey");
@@ -27,9 +32,9 @@ function showStatus(message, type = "success") {
  * Loads saved GitHub and OpenAI API credentials from browser storage and populates the input fields.
  * Displays an error status message if loading fails.
  */
-async function loadSettings() {
+async function displaySettings() {
   try {
-    const settings = await chrome.storage.sync.get();
+    const settings = await getStoredSettings();
     if (settings.githubToken) {
       githubTokenInput.value = settings.githubToken;
     }
@@ -46,7 +51,7 @@ async function loadSettings() {
  * Saves the GitHub token and OpenAI API key from input fields to browser storage.
  * Displays a status message indicating success or failure. If either input is empty, shows an error and does not save.
  */
-async function saveSettings() {
+async function saveFormSettings() {
   const githubToken = githubTokenInput.value.trim();
   const openAIApiKey = openAIApiKeyInput.value.trim();
 
@@ -56,7 +61,7 @@ async function saveSettings() {
   }
 
   try {
-    await chrome.storage.sync.set({ githubToken, openAIApiKey });
+    await persistSettings({ githubToken, openAIApiKey });
     showStatus("Settings saved successfully!");
   } catch (error) {
     console.error("Failed to save settings:", error);
@@ -64,5 +69,5 @@ async function saveSettings() {
   }
 }
 
-document.addEventListener("DOMContentLoaded", loadSettings);
-saveButton.addEventListener("click", saveSettings);
+document.addEventListener("DOMContentLoaded", displaySettings);
+saveButton.addEventListener("click", saveFormSettings);

--- a/extension/options.js
+++ b/extension/options.js
@@ -9,7 +9,7 @@ let statusTimeout;
 
 /**
  * Displays a temporary status message with a specified type on the options page.
- * 
+ *
  * @param {string} message - The message to display.
  * @param {string} [type="success"] - The type of status message ("success" or "error"), which determines the CSS class.
  */
@@ -29,7 +29,7 @@ function showStatus(message, type = "success") {
  */
 async function loadSettings() {
   try {
-    const settings = await chrome.storage.local.get();
+    const settings = await chrome.storage.sync.get();
     if (settings.githubToken) {
       githubTokenInput.value = settings.githubToken;
     }
@@ -56,7 +56,7 @@ async function saveSettings() {
   }
 
   try {
-    await chrome.storage.local.set({ githubToken, openAIApiKey });
+    await chrome.storage.sync.set({ githubToken, openAIApiKey });
     showStatus("Settings saved successfully!");
   } catch (error) {
     console.error("Failed to save settings:", error);

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -1,0 +1,50 @@
+let cachedSettings = null;
+
+/**
+ * Load settings from chrome.storage.sync with fallback migration from local storage.
+ * @returns {Promise<object>} Resolves to the settings object or an empty object on failure.
+ */
+export async function loadSettings() {
+  if (cachedSettings) return cachedSettings;
+  try {
+    const syncSettings = await chrome.storage.sync.get();
+    if (!syncSettings.githubToken || !syncSettings.openAIApiKey) {
+      const localSettings = await chrome.storage.local.get();
+      const updates = {};
+      if (!syncSettings.githubToken && localSettings.githubToken) {
+        updates.githubToken = localSettings.githubToken;
+      }
+      if (!syncSettings.openAIApiKey && localSettings.openAIApiKey) {
+        updates.openAIApiKey = localSettings.openAIApiKey;
+      }
+      if (Object.keys(updates).length > 0) {
+        try {
+          await chrome.storage.sync.set(updates);
+        } catch (setErr) {
+          console.error("Failed to migrate settings to sync storage:", setErr);
+        }
+        Object.assign(syncSettings, updates);
+      }
+    }
+    cachedSettings = syncSettings;
+    return syncSettings;
+  } catch (error) {
+    console.error("Failed to load settings:", error);
+    return {};
+  }
+}
+
+/**
+ * Save settings to chrome.storage.sync and update cache.
+ * @param {object} newSettings
+ * @returns {Promise<void>}
+ */
+export async function saveSettings(newSettings) {
+  try {
+    await chrome.storage.sync.set(newSettings);
+    cachedSettings = { ...(cachedSettings || {}), ...newSettings };
+  } catch (error) {
+    console.error("Failed to save settings:", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- load config from `chrome.storage.sync`
- read API key from sync storage when calling OpenAI
- save settings to sync storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687813fc23e883339e80cbb80b8276a9

## Summary by Sourcery

Migrate settings storage from chrome.storage.local to chrome.storage.sync and fix API key retrieval for OpenAI calls.

Bug Fixes:
- Ensure OpenAI API key is loaded from sync storage when not provided in config
- Throw explicit error if the API key is missing in getReviewForPatch

Enhancements:
- Introduce getStoredApiKey to fetch the API key from chrome.storage.sync
- Update options page to load and save GitHub token and OpenAI API key using sync storage
- Switch config loader to use chrome.storage.sync for retrieving settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extension settings and API keys are now synchronized across devices using Chrome's sync storage.
  * Improved error messaging when an API key is missing, prompting users to add it in the options page.

* **Bug Fixes**
  * Ensured consistent retrieval and saving of configuration data by switching all storage operations to synchronized storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->