### PR TITLE
Enhance PR review with personas and summary

### DIFF
--- a/extension/config.js
+++ b/extension/config.js
@@ -51,9 +51,22 @@ export async function loadConfig() {
           : DEFAULT_TEMPERATURE,
       systemPrompt:
         settings.systemPrompt ||
-        PERSONA_PROMPTS[settings.reviewPersona] ||
+        (settings.reviewPersona &&
+        Object.prototype.hasOwnProperty.call(
+          PERSONA_PROMPTS,
+          settings.reviewPersona,
+        )
+          ? PERSONA_PROMPTS[settings.reviewPersona]
+          : null) ||
         DEFAULT_PROMPT,
-      reviewPersona: settings.reviewPersona || "",
+      reviewPersona:
+        settings.reviewPersona &&
+        Object.prototype.hasOwnProperty.call(
+          PERSONA_PROMPTS,
+          settings.reviewPersona,
+        )
+          ? settings.reviewPersona
+          : "",
       concurrencyLimit: settings.concurrencyLimit || 5,
       error: null,
     };

--- a/extension/config.js
+++ b/extension/config.js
@@ -50,8 +50,8 @@ export async function loadConfig() {
           ? settings.temperature
           : DEFAULT_TEMPERATURE,
       systemPrompt:
-        PERSONA_PROMPTS[settings.reviewPersona] ||
         settings.systemPrompt ||
+        PERSONA_PROMPTS[settings.reviewPersona] ||
         DEFAULT_PROMPT,
       reviewPersona: settings.reviewPersona || "",
       concurrencyLimit: settings.concurrencyLimit || 5,

--- a/extension/config.js
+++ b/extension/config.js
@@ -6,6 +6,7 @@
  * @property {number} maxTokens
  * @property {number} temperature
  * @property {string} systemPrompt
+ * @property {string} [reviewPersona]
  * @property {number} concurrencyLimit
  * @property {string|null} error
  */
@@ -14,6 +15,13 @@ const DEFAULT_MODEL = "gpt-4o";
 const DEFAULT_MAX_TOKENS = 1500;
 const DEFAULT_TEMPERATURE = 0.2;
 const DEFAULT_PROMPT = `You are an expert code reviewer. Your task is to analyze the provided code diff and return feedback in a JSON format. The JSON object should contain an array of "comments", where each comment has "line" (the line number relative to the diff) and "body" (your feedback). Provide feedback only if you find a substantive issue or a significant improvement. If there are no issues, return an empty "comments" array. The feedback should be concise and actionable. Diff format: Unified. The line number is the line number in the file that was changed.`;
+
+const PERSONA_PROMPTS = {
+  strict:
+    "You are a strict code reviewer who enforces repository guidelines such as using plain JavaScript, keeping code in the extension directory, and formatting with Prettier. Provide terse feedback only when necessary. Return JSON as described.",
+  mentor:
+    "You are a friendly mentor guiding contributors according to repository guidelines like using plain JavaScript and Prettier. Offer helpful suggestions in the JSON format described.",
+};
 
 /**
  * Retrieves the application configuration from Chrome local storage, applying default values for optional settings and validating the presence of required API keys.
@@ -41,7 +49,11 @@ export async function loadConfig() {
         settings.temperature !== undefined
           ? settings.temperature
           : DEFAULT_TEMPERATURE,
-      systemPrompt: settings.systemPrompt || DEFAULT_PROMPT,
+      systemPrompt:
+        PERSONA_PROMPTS[settings.reviewPersona] ||
+        settings.systemPrompt ||
+        DEFAULT_PROMPT,
+      reviewPersona: settings.reviewPersona || "",
       concurrencyLimit: settings.concurrencyLimit || 5,
       error: null,
     };

--- a/extension/githubApi.js
+++ b/extension/githubApi.js
@@ -142,3 +142,28 @@ export async function postComment({
   );
   return handleGitHubResponse(res);
 }
+
+/**
+ * Posts a summary comment to the pull request conversation.
+ * @param {Object} params
+ * @param {{owner:string, repo:string, prNumber:number}} params.prDetails
+ * @param {string} params.token
+ * @param {string} params.body
+ * @returns {Promise<Object|null>} The created comment object or null.
+ */
+export async function postSummaryComment({ prDetails, token, body }) {
+  const { owner, repo, prNumber } = prDetails;
+  const res = await fetch(
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/issues/${prNumber}/comments`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/vnd.github.v3+json",
+      },
+      body: JSON.stringify({ body }),
+    },
+  );
+  return handleGitHubResponse(res);
+}

--- a/extension/options.html
+++ b/extension/options.html
@@ -63,6 +63,15 @@
       <input type="number" id="temperature" step="0.1" min="0" max="2" />
     </div>
 
+    <div class="token-group">
+      <label for="reviewPersona">Review Persona</label>
+      <select id="reviewPersona">
+        <option value="">Default</option>
+        <option value="strict">Strict Code Reviewer</option>
+        <option value="mentor">Friendly Mentor</option>
+      </select>
+    </div>
+
     <div id="form-status" class="status"></div>
 
     <button id="save-settings">Save Settings</button>

--- a/extension/options.js
+++ b/extension/options.js
@@ -11,6 +11,7 @@ const openAIApiKeyInput = document.getElementById("openAIApiKey");
 const openAIModelInput = document.getElementById("openAIModel");
 const maxTokensInput = document.getElementById("maxTokens");
 const temperatureInput = document.getElementById("temperature");
+const reviewPersonaInput = document.getElementById("reviewPersona");
 const statusElement = document.getElementById("form-status");
 
 let statusTimeout;
@@ -53,6 +54,9 @@ async function displaySettings() {
     if (settings.temperature !== undefined) {
       temperatureInput.value = settings.temperature;
     }
+    if (settings.reviewPersona) {
+      reviewPersonaInput.value = settings.reviewPersona;
+    }
   } catch (error) {
     console.error("Failed to load settings:", error);
     showStatus("Error loading settings.", "error");
@@ -69,6 +73,7 @@ async function saveFormSettings() {
   const openAIModel = openAIModelInput.value.trim();
   const maxTokens = parseInt(maxTokensInput.value, 10);
   const temperature = parseFloat(temperatureInput.value);
+  const reviewPersona = reviewPersonaInput.value;
 
   if (!githubToken || !openAIApiKey) {
     showStatus("Both GitHub Token and OpenAI API Key are required.", "error");
@@ -98,6 +103,7 @@ async function saveFormSettings() {
       openAIModel,
       maxTokens,
       temperature,
+      reviewPersona,
     });
     showStatus("Settings saved successfully!");
   } catch (error) {

--- a/test/githubApi.test.js
+++ b/test/githubApi.test.js
@@ -71,4 +71,31 @@ describe("githubApi", () => {
       );
     });
   });
+
+  describe("postSummaryComment", () => {
+    it("posts a summary to the PR conversation", async () => {
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ id: 123 }),
+        headers: { get: () => null },
+      });
+
+      const result = await github.postSummaryComment({
+        prDetails: { owner: "o", repo: "r", prNumber: 5 },
+        token: "t",
+        body: "summary",
+      });
+
+      expect(fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/o/r/issues/5/comments",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ Authorization: "Bearer t" }),
+          body: JSON.stringify({ body: "summary" }),
+        }),
+      );
+      expect(result).toEqual({ id: 123 });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add persona mapping in config and expose setting in options page
- collect per-file review comments into a summary comment
- provide `postSummaryComment` GitHub API helper
- update options script to save persona selection
- test summary comment posting

## Testing
- `npx prettier --write extension/config.js extension/content.js extension/githubApi.js extension/options.html extension/options.js test/githubApi.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68782d91b42c8333bfa61962f2e5c8d8

## Summary by Sourcery

Introduce review personas and summarize per-file feedback into a single comment on the PR conversation.

New Features:
- Allow users to select a review persona (strict or mentor) in the options page
- Compile individual file review comments into an aggregated summary and post it as a single comment

Enhancements:
- Add `postSummaryComment` helper to the GitHub API module
- Incorporate persona-based system prompts in configuration

Tests:
- Add a unit test for the `postSummaryComment` function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Review Persona" option in the settings, allowing users to choose between Default, Strict Code Reviewer, and Friendly Mentor personas for PR reviews.
  * Review summary comments are now automatically posted to GitHub pull requests, summarizing AI feedback across all files.

* **Bug Fixes**
  * Improved error handling when posting summary comments to GitHub to prevent interruptions in the review flow.

* **Tests**
  * Added tests to verify correct posting of summary comments to GitHub pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->