### PR TITLE
Add feedback loop with thumbs buttons

### DIFF
--- a/extension/feedback.css
+++ b/extension/feedback.css
@@ -1,0 +1,10 @@
+.ai-feedback-buttons {
+  margin-top: 4px;
+}
+
+.ai-feedback-buttons button {
+  margin-right: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}

--- a/extension/feedback.js
+++ b/extension/feedback.js
@@ -1,0 +1,114 @@
+// extension/feedback.js
+import * as github from "./githubApi.js";
+
+const STORAGE_KEY = "aiFeedback";
+let styleInjected = false;
+
+function injectStyle() {
+  if (styleInjected) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = chrome.runtime.getURL("feedback.css");
+  document.head.appendChild(link);
+  styleInjected = true;
+}
+
+export async function recordComment({ owner, repo, prNumber, commentId }) {
+  const data = await chrome.storage.local.get(STORAGE_KEY);
+  const list = data[STORAGE_KEY] || [];
+  list.push({ owner, repo, prNumber, commentId, rating: null, adopted: null });
+  await chrome.storage.local.set({ [STORAGE_KEY]: list });
+}
+
+export async function saveRating(commentId, rating) {
+  const data = await chrome.storage.local.get(STORAGE_KEY);
+  const list = data[STORAGE_KEY] || [];
+  const rec = list.find((r) => r.commentId === commentId);
+  if (rec) {
+    rec.rating = rating;
+    await chrome.storage.local.set({ [STORAGE_KEY]: list });
+  }
+}
+
+async function updateAdoption(prDetails, token) {
+  const data = await chrome.storage.local.get(STORAGE_KEY);
+  const list = data[STORAGE_KEY] || [];
+  const relevant = list.filter(
+    (r) =>
+      r.owner === prDetails.owner &&
+      r.repo === prDetails.repo &&
+      r.prNumber === prDetails.prNumber,
+  );
+  for (const r of relevant) {
+    try {
+      const comment = await github.getReviewComment(
+        {
+          owner: prDetails.owner,
+          repo: prDetails.repo,
+          commentId: r.commentId,
+        },
+        token,
+      );
+      if (comment && comment.position === null) {
+        r.adopted = true;
+      } else {
+        r.adopted = false;
+      }
+    } catch (e) {
+      console.error("Failed to check comment adoption", e);
+    }
+  }
+  await chrome.storage.local.set({ [STORAGE_KEY]: list });
+}
+
+export function startMergeTracker(prDetails, token) {
+  const interval = setInterval(async () => {
+    try {
+      const pr = await github.getPRData(prDetails, token);
+      if (pr && pr.merged_at) {
+        clearInterval(interval);
+        await updateAdoption(prDetails, token);
+      }
+    } catch (e) {
+      console.error("Merge check failed", e);
+    }
+  }, 60000);
+}
+
+function addButtons(bodyEl, commentId) {
+  injectStyle();
+  if (bodyEl.querySelector(".ai-feedback-buttons")) return;
+  const container = document.createElement("div");
+  container.className = "ai-feedback-buttons";
+  const up = document.createElement("button");
+  up.textContent = "\uD83D\uDC4D"; // thumbs up
+  const down = document.createElement("button");
+  down.textContent = "\uD83D\uDC4E"; // thumbs down
+  container.appendChild(up);
+  container.appendChild(down);
+  up.addEventListener("click", () => saveRating(parseInt(commentId, 10), "up"));
+  down.addEventListener("click", () =>
+    saveRating(parseInt(commentId, 10), "down"),
+  );
+  bodyEl.appendChild(container);
+}
+
+function attachButtons() {
+  const containers = document.querySelectorAll(".js-comment-container");
+  containers.forEach((c) => {
+    const id = c.getAttribute("data-comment-id");
+    const body = c.querySelector(".js-comment-body");
+    if (!id || !body) return;
+    const text = body.textContent || "";
+    if (text.trim().startsWith("AI Suggestion:")) {
+      addButtons(body, id);
+    }
+  });
+}
+
+export function observeComments() {
+  attachButtons();
+  const observer = new MutationObserver(attachButtons);
+  observer.observe(document.body, { childList: true, subtree: true });
+  return observer;
+}

--- a/extension/githubApi.js
+++ b/extension/githubApi.js
@@ -193,3 +193,22 @@ export async function postSummaryComment({ prDetails, token, body }) {
   );
   return handleGitHubResponse(res);
 }
+
+/**
+ * Retrieve a single review comment by ID.
+ * @param {{owner:string, repo:string, commentId:number}} params
+ * @param {string} token
+ * @returns {Promise<Object|null>}
+ */
+export async function getReviewComment({ owner, repo, commentId }, token) {
+  const res = await fetch(
+    `${GITHUB_API_URL}/repos/${owner}/${repo}/pulls/comments/${commentId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github.v3+json",
+      },
+    },
+  );
+  return handleGitHubResponse(res);
+}

--- a/test/githubApi.test.js
+++ b/test/githubApi.test.js
@@ -146,4 +146,28 @@ describe("githubApi", () => {
       expect(result).toEqual({ id: 10 });
     });
   });
+
+  describe("getReviewComment", () => {
+    it("fetches a single review comment", async () => {
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 7, position: null }),
+        headers: { get: () => null },
+      });
+
+      const result = await github.getReviewComment(
+        { owner: "o", repo: "r", commentId: 7 },
+        "tok",
+      );
+
+      expect(fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/o/r/pulls/comments/7",
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer tok" }),
+        }),
+      );
+      expect(result).toEqual({ id: 7, position: null });
+    });
+  });
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -29,6 +29,11 @@ jest.unstable_mockModule("../extension/ui.js", () => ({
   updateStatus: jest.fn(),
   removeStatusIndicator: jest.fn(),
 }));
+jest.unstable_mockModule("../extension/feedback.js", () => ({
+  observeComments: jest.fn(),
+  startMergeTracker: jest.fn(),
+  recordComment: jest.fn(),
+}));
 
 beforeEach(() => {
   resetChrome();


### PR DESCRIPTION
## Summary
- save AI review comments and user ratings in `feedback.js`
- post comments with an `AI Suggestion:` prefix and track them
- after reviews finish, attach feedback buttons and monitor merges
- expose `getReviewComment` helper in GitHub API module
- mock feedback module in integration tests
- add tests for new API helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68783cfa2ba88333a67f07955d8837a6