### PR TITLE
Implement multi-agent review flow

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -76,7 +76,10 @@ async function runReviewFlow(prDetails) {
           ui.updateStatus(
             `Analyzing files... (${filesAnalyzed + 1}/${filesToReview.length})`,
           );
-          const feedback = await openai.getReviewForPatch(file.patch, config);
+          const feedback = await openai.getMultiAgentReviewForPatch(
+            file.patch,
+            config,
+          );
           if (
             feedback &&
             Array.isArray(feedback.comments) &&

--- a/extension/openaiApi.js
+++ b/extension/openaiApi.js
@@ -1,5 +1,6 @@
 const OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
 const MAX_METADATA_LENGTH = 200;
+const DEFAULT_MODEL = "gpt-4o";
 
 function truncateText(text, maxLength = MAX_METADATA_LENGTH) {
   const trimmed = (text || "").trim();
@@ -122,8 +123,8 @@ export async function getReviewForPatch(patch, config = {}) {
 async function synthesizeFeedback(reviews, config = {}) {
   const settings = await loadSettings();
   const openAIApiKey = config.openAIApiKey || settings.openAIApiKey;
-  const model = config.synthModel || config.openAIModel;
-  const { maxTokens, temperature } = config;
+  const model = config.synthModel || config.openAIModel || DEFAULT_MODEL;
+  const { maxTokens = 512, temperature = 0.7 } = config;
 
   const summaryPrompt =
     "You are a senior reviewer tasked with consolidating feedback from multiple reviewers. " +

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -3,7 +3,7 @@ import { setupChrome, resetChrome } from "./chromeMock.js";
 
 // Mock modules used by content.js
 jest.unstable_mockModule("../extension/openaiApi.js", () => ({
-  getReviewForPatch: jest.fn().mockResolvedValue({ comments: [] }),
+  getMultiAgentReviewForPatch: jest.fn().mockResolvedValue({ comments: [] }),
 }));
 jest.unstable_mockModule("../extension/githubApi.js", () => ({
   fetchAllPRFiles: jest
@@ -62,5 +62,5 @@ test("popup click triggers OpenAI call", async () => {
   );
 
   const openai = await import("../extension/openaiApi.js");
-  expect(openai.getReviewForPatch).toHaveBeenCalled();
+  expect(openai.getMultiAgentReviewForPatch).toHaveBeenCalled();
 });

--- a/test/openaiApi.test.js
+++ b/test/openaiApi.test.js
@@ -119,32 +119,55 @@ describe("getMultiAgentReviewForPatch", () => {
     fetchMock.mockReset();
   });
 
-  it("runs multiple reviews and synthesizes them", async () => {
-    const review1 = {
-      choices: [{ message: { content: JSON.stringify({ comments: [] }) } }],
-    };
-    const review2 = {
-      choices: [{ message: { content: JSON.stringify({ comments: [] }) } }],
-    };
-    const final = {
-      choices: [
-        {
-          message: {
-            content: JSON.stringify({ comments: [{ line: 1, body: "x" }] }),
-          },
+  const review = {
+    choices: [{ message: { content: JSON.stringify({ comments: [] }) } }],
+  };
+  const final = {
+    choices: [
+      {
+        message: {
+          content: JSON.stringify({ comments: [{ line: 1, body: "x" }] }),
         },
-      ],
-    };
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => review1,
+      },
+    ],
+  };
+
+  [1, 2, 3].forEach((agentCount) => {
+    it(`runs ${agentCount} reviews and synthesizes them`, async () => {
+      for (let i = 0; i < agentCount; i++) {
+        fetchMock.mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => review,
+        });
+      }
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => final,
+      });
+
+      const res = await getMultiAgentReviewForPatch("d", {
+        openAIApiKey: "k",
+        openAIModel: "gpt",
+        maxTokens: 10,
+        temperature: 0,
+        agentCount,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(agentCount + 1);
+      expect(res).toEqual({ comments: [{ line: 1, body: "x" }] });
     });
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => review2,
-    });
+  });
+
+  it("defaults to 3 agents when agentCount is missing", async () => {
+    for (let i = 0; i < 3; i++) {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => review,
+      });
+    }
     fetchMock.mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -156,10 +179,9 @@ describe("getMultiAgentReviewForPatch", () => {
       openAIModel: "gpt",
       maxTokens: 10,
       temperature: 0,
-      agentCount: 2,
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(res).toEqual({ comments: [{ line: 1, body: "x" }] });
   });
 });


### PR DESCRIPTION
## Summary
- introduce `getMultiAgentReviewForPatch` that aggregates parallel reviews using a synthesizer step
- use the new multi-agent approach in the content script
- test multi-agent review logic and update integration tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68784568ebac83339ab15124fb057399

## Summary by Sourcery

Introduce a multi-agent review flow that aggregates feedback from multiple parallel AI reviewers and synthesizes their comments into a consolidated review.

New Features:
- Add getMultiAgentReviewForPatch to perform parallel reviews and synthesize feedback.

Enhancements:
- Update content script to use the multi-agent review approach instead of single-agent review.

Tests:
- Add and update unit and integration tests to cover multi-agent review logic.