### PR TITLE
Store API keys locally, refine prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ All extension code lives in the `extension/` folder.
    OpenAI credentials. Copy `extension/settings.example.json` to
    `extension/settings.local.json` for non-secret settings. The extension reads
    tokens from environment variables so they are never stored in source control.
+   When entered via the options page, credentials are saved only to Chrome's
+   local storage and will not sync across browsers.
 
 3. **Format and test.** Use Prettier to format your code and run the test
    suite before committing:

--- a/extension/config.js
+++ b/extension/config.js
@@ -15,7 +15,7 @@
 const DEFAULT_MODEL = "gpt-4o";
 const DEFAULT_MAX_TOKENS = 1500;
 const DEFAULT_TEMPERATURE = 0.2;
-const DEFAULT_PROMPT = `You are an expert code reviewer. Think step by step about the diff you receive. Return a JSON object with two fields: "reasoning" - a short summary of your thought process - and "comments" - an array where each entry has "line" and "body" keys. Provide feedback only for substantive issues or improvements. The diff format is Unified and line numbers refer to the changed file.`;
+const DEFAULT_PROMPT = `You are an expert code reviewer. Analyze the diff carefully but keep your reasoning concise. Return actionable comments only for meaningful issues or improvements. Output JSON with "reasoning" (one short paragraph) and "comments" (array of {"line", "body"}). The diff format is Unified and line numbers refer to the changed file.`;
 
 const PERSONA_PROMPTS = {
   strict:

--- a/extension/openaiApi.js
+++ b/extension/openaiApi.js
@@ -9,6 +9,12 @@ function truncateText(text, maxLength = MAX_METADATA_LENGTH) {
     : trimmed;
 }
 
+function formatUserContent(content, model) {
+  return /claude/i.test(model || "")
+    ? `<analysis>\n${content}\n</analysis>`
+    : content;
+}
+
 /**
  * Submits a unified diff patch to the OpenAI API for automated code review and returns structured feedback.
  *
@@ -77,7 +83,10 @@ export async function getReviewForPatch(patch, config = {}) {
         { role: "system", content: systemPrompt },
         {
           role: "user",
-          content: `${prContext}${extraContext}Analyze the following diff step by step. Provide a short summary of your reasoning and inline comments. Return a JSON object with \"reasoning\" and \"comments\" as described.\n\n${patch}`,
+          content: formatUserContent(
+            `${prContext}${extraContext}Analyze the following diff step by step. Provide a short summary of your reasoning and inline comments. Return a JSON object with \"reasoning\" and \"comments\" as described.\n\n${patch}`,
+            openAIModel,
+          ),
         },
       ],
       response_format: { type: "json_object" },

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -1,33 +1,31 @@
 let cachedSettings = null;
 
 /**
- * Load settings from chrome.storage.sync with fallback migration from local storage.
+ * Load settings from chrome.storage.local with migration from sync storage for existing users.
  * @returns {Promise<object>} Resolves to the settings object or an empty object on failure.
  */
 export async function loadSettings() {
   if (cachedSettings) return cachedSettings;
   try {
+    const localSettings = await chrome.storage.local.get();
     const syncSettings = await chrome.storage.sync.get();
-    if (!syncSettings.githubToken || !syncSettings.openAIApiKey) {
-      const localSettings = await chrome.storage.local.get();
-      const updates = {};
-      if (!syncSettings.githubToken && localSettings.githubToken) {
-        updates.githubToken = localSettings.githubToken;
-      }
-      if (!syncSettings.openAIApiKey && localSettings.openAIApiKey) {
-        updates.openAIApiKey = localSettings.openAIApiKey;
-      }
-      if (Object.keys(updates).length > 0) {
-        try {
-          await chrome.storage.sync.set(updates);
-        } catch (setErr) {
-          console.error("Failed to migrate settings to sync storage:", setErr);
-        }
-        Object.assign(syncSettings, updates);
-      }
+    const updates = {};
+    if (!localSettings.githubToken && syncSettings.githubToken) {
+      updates.githubToken = syncSettings.githubToken;
     }
-    cachedSettings = syncSettings;
-    return syncSettings;
+    if (!localSettings.openAIApiKey && syncSettings.openAIApiKey) {
+      updates.openAIApiKey = syncSettings.openAIApiKey;
+    }
+    if (Object.keys(updates).length > 0) {
+      try {
+        await chrome.storage.local.set(updates);
+      } catch (setErr) {
+        console.error("Failed to migrate settings to local storage:", setErr);
+      }
+      Object.assign(localSettings, updates);
+    }
+    cachedSettings = localSettings;
+    return localSettings;
   } catch (error) {
     console.error("Failed to load settings:", error);
     return {};
@@ -35,13 +33,13 @@ export async function loadSettings() {
 }
 
 /**
- * Save settings to chrome.storage.sync and update cache.
+ * Save settings to chrome.storage.local and update cache.
  * @param {object} newSettings
  * @returns {Promise<void>}
  */
 export async function saveSettings(newSettings) {
   try {
-    await chrome.storage.sync.set(newSettings);
+    await chrome.storage.local.set(newSettings);
     cachedSettings = { ...(cachedSettings || {}), ...newSettings };
   } catch (error) {
     console.error("Failed to save settings:", error);


### PR DESCRIPTION
## Summary
- store API credentials using `chrome.storage.local` with migration from `chrome.storage.sync`
- clarify credential storage in the README
- refine default prompt wording for more concise AI reviews
- add Claude model prompt formatting

## Testing
- `npm install`
- `npm test`
- `npx prettier --write .`

------
https://chatgpt.com/codex/tasks/task_e_687973a879508333beec0828d1883656