### PR TITLE
ci: add ios adhoc export workflow

### DIFF
--- a/.github/workflows/ios-adhoc-export.yml
+++ b/.github/workflows/ios-adhoc-export.yml
@@ -1,0 +1,142 @@
+name: iOS AdHoc Signed IPA
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build-adhoc:
+    runs-on: macos-15
+
+    env:
+      SCHEME: monGARS
+      CONFIGURATION: Release
+      ARCHIVE_PATH: build/monGARS.xcarchive
+      DERIVED_DATA: build/DerivedData
+      RESULT_BUNDLE: build/DerivedData/ResultBundle_build.xcresult
+
+      BUNDLE_ID_PREFIX: anardoni.export
+      BUNDLE_ID_SUFFIX: ${{ secrets.BUNDLE_ID_SUFFIX }}
+      TEAM_ID: ${{ secrets.TEAM_ID }}
+
+      KEYCHAIN_NAME: build-signing.keychain-db
+      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+
+      P12_BASE64: ${{ secrets.P12_BASE64 }}
+      P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+      MOBILEPROVISION_BASE64: ${{ secrets.MOBILEPROVISION_BASE64 }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare scripts
+        run: |
+          mkdir -p scripts signing
+          cat > scripts/import_signing.sh <<'BASH'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          P12_PATH="$1"; P12_PASSWORD="$2"; MP_PATH="$3"; KC_NAME="$4"; KC_PASS="$5"
+          security create-keychain -p "$KC_PASS" "$KC_NAME"
+          security set-keychain-settings -lut 21600 "$KC_NAME"
+          security unlock-keychain -p "$KC_PASS" "$KC_NAME"
+          security import "$P12_PATH" -k "$KC_NAME" -P "$P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PASS" "$KC_NAME" || true
+          security list-keychains -d user -s "$KC_NAME"
+          security default-keychain -s "$KC_NAME"
+          PP_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"; mkdir -p "$PP_DIR"
+          PLIST_TMP=$(mktemp); security cms -D -i "$MP_PATH" > "$PLIST_TMP"
+          UUID=$(/usr/libexec/PlistBuddy -c 'Print UUID' "$PLIST_TMP")
+          cp "$MP_PATH" "$PP_DIR/$UUID.mobileprovision"
+          echo "PROFILE_UUID=$UUID" >> "$GITHUB_ENV"
+          BASH
+          chmod +x scripts/import_signing.sh
+
+          cat > scripts/export_ipa.sh <<'BASH'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          ARCHIVE_PATH="$1"; EXPORT_OPTS="$2"; EXPORT_DIR="$3"
+          mkdir -p "$EXPORT_DIR"
+          xcodebuild -exportArchive -archivePath "$ARCHIVE_PATH" -exportPath "$EXPORT_DIR" -exportOptionsPlist "$EXPORT_OPTS" -allowProvisioningUpdates
+          ls -la "$EXPORT_DIR"
+          BASH
+          chmod +x scripts/export_ipa.sh
+
+      - name: Decode signing files
+        run: |
+          echo "$P12_BASE64" | base64 --decode > signing/cert.p12
+          echo "$MOBILEPROVISION_BASE64" | base64 --decode > signing/profile.mobileprovision
+
+      - name: Import certificate & provisioning profile
+        run: |
+          bash scripts/import_signing.sh \
+            signing/cert.p12 \
+            "$P12_PASSWORD" \
+            signing/profile.mobileprovision \
+            "$KEYCHAIN_NAME" \
+            "$KEYCHAIN_PASSWORD"
+
+      - name: Resolve profile name
+        id: profile
+        run: |
+          PROFILE_PLIST=$(mktemp)
+          /usr/bin/security cms -D -i signing/profile.mobileprovision > "$PROFILE_PLIST"
+          PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print Name' "$PROFILE_PLIST")
+          echo "name=$PROFILE_NAME" >> $GITHUB_OUTPUT
+
+      - name: Xcode Archive (manual signing)
+        run: |
+          set -euxo pipefail
+          rm -rf "$ARCHIVE_PATH" "$DERIVED_DATA" "$RESULT_BUNDLE" || true
+          BUNDLE_ID="${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}"
+          xcodebuild \
+            -scheme "$SCHEME" \
+            -configuration "$CONFIGURATION" \
+            -archivePath "$ARCHIVE_PATH" \
+            -destination "generic/platform=iOS" \
+            -derivedDataPath "$DERIVED_DATA" \
+            -resultBundlePath "$RESULT_BUNDLE" \
+            archive \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM="${TEAM_ID}" \
+            PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
+            PROVISIONING_PROFILE_SPECIFIER="${{ steps.profile.outputs.name }}" \
+            OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_NAME"
+
+      - name: Create exportOptions.plist
+        run: |
+          cat > exportOptions.plist <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key><string>ad-hoc</string>
+            <key>signingStyle</key><string>manual</string>
+            <key>teamID</key><string>${TEAM_ID}</string>
+            <key>compileBitcode</key><false/>
+            <key>stripSwiftSymbols</key><true/>
+            <key>destination</key><string>export</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}</key><string>${{ steps.profile.outputs.name }}</string>
+            </dict>
+          </dict>
+          </plist>
+          PLIST
+
+      - name: Export IPA
+        run: |
+          bash scripts/export_ipa.sh "$ARCHIVE_PATH" exportOptions.plist export
+
+      - name: Upload IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: monGARS-AdHoc-IPA
+          path: export/*.ipa
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          security delete-keychain "$KEYCHAIN_NAME" || true


### PR DESCRIPTION
## Summary
- add an iOS AdHoc export GitHub Actions workflow that archives and signs the monGARS app using uploaded signing secrets
- include helper scripts within the workflow to import signing assets and export the IPA artifact

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d23786c1608333808ed97844cd1c5e

## Summary by Sourcery

Add a GitHub Actions workflow to archive, manually sign, and export the monGARS iOS app as an AdHoc IPA.

Enhancements:
- Include helper shell scripts for importing signing assets and exporting the IPA.

CI:
- Create ios-adhoc-export workflow to build and export an AdHoc-signed IPA on macOS runners triggered by push, pull_request, or manual dispatch.
- Decode base64-encoded signing secrets, import certificate and provisioning profile into a temporary keychain, and upload the resulting IPA artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to build and export iOS AdHoc IPAs with manual code signing.
  * Automatically uploads the generated IPA as a downloadable build artifact.
  * Ensures signing assets are handled securely and cleaned up after each run.
  * Improves reliability with strict error handling and consistent build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->