### PR TITLE
Enhance deep capture reliability and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ wifi-handshake-c/
    - iOS (simulator): `npm run ios`
    - Android (device/emulator): `npm run android`
 
+4. **Run a local iOS build without signing**
+
+   ```bash
+   npm run ios:build
+   ```
+
+   The command builds the iOS workspace for the simulator, which is useful when Xcode signing assets are unavailable (for example on CI or when working without provisioning profiles).
+
 ## Quality checks
 
 - Lint the codebase with `npm run lint`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ wifi-handshake-c/
 
 4. **Run a local iOS build without signing**
 
+   Prerequisites: Install the Xcode command-line tools and CocoaPods. If Pods have not been installed yet for the iOS workspace, run `npx pod-install` first to avoid build failures.
+
    ```bash
+   npx pod-install
    npm run ios:build
    ```
 

--- a/wifi-handshake-c/ios/WiFiHandshakeCapture/WifiCapture.entitlements
+++ b/wifi-handshake-c/ios/WiFiHandshakeCapture/WifiCapture.entitlements
@@ -4,5 +4,9 @@
   <dict>
     <key>com.apple.developer.networking.wifi-info</key>
     <true/>
+    <key>com.apple.developer.networking.networkextension</key>
+    <array>
+      <string>packet-tunnel-provider</string>
+    </array>
   </dict>
 </plist>

--- a/wifi-handshake-c/ios/WiFiHandshakeCapture/WifiCapture.entitlements
+++ b/wifi-handshake-c/ios/WiFiHandshakeCapture/WifiCapture.entitlements
@@ -2,15 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.developer.networking.networkextension</key>
-    <array>
-      <string>packet-tunnel-provider</string>
-    </array>
     <key>com.apple.developer.networking.wifi-info</key>
     <true/>
-    <key>com.apple.security.application-groups</key>
-    <array>
-      <string>group.com.yourapp.wificapture</string>
-    </array>
   </dict>
 </plist>

--- a/wifi-handshake-c/ios/WifiCaptureExtension/PacketTunnelProvider.swift
+++ b/wifi-handshake-c/ios/WifiCaptureExtension/PacketTunnelProvider.swift
@@ -4,100 +4,142 @@ import NetworkExtension
 import os.log
 
 final class PacketTunnelProvider: NEPacketTunnelProvider {
+  private let logger = Logger(subsystem: "WifiCaptureExtension", category: "PacketTunnelProvider")
   private var udpProxy: UDPProxy?
+  private var filterData: Data?
   private var stats = CaptureStats()
-  private let logger = Logger(subsystem: "WifiCaptureExtension", category: "PacketTunnel")
 
   override func startTunnel(options: [String: NSObject]?, completionHandler: @escaping (Error?) -> Void) {
     guard
-      let configuration = protocolConfiguration.providerConfiguration,
-      let port = configuration["udpPort"] as? Int
+      let provider = protocolConfiguration as? NETunnelProviderProtocol,
+      let configuration = provider.providerConfiguration,
+      let portValue = configuration["udpPort"] as? Int,
+      let port = NWEndpoint.Port(rawValue: UInt16(portValue))
     else {
-      completionHandler(NSError(domain: "WifiCaptureExtension", code: -1, userInfo: [NSLocalizedDescriptionKey: "Missing UDP port"]))
-      return
-    }
-
-    let filter = configuration["filter"] as? String ?? ""
-
-    do {
-      udpProxy = try UDPProxy(port: port)
-    } catch {
+      logger.error("Invalid UDP port in configuration")
+      let error = NSError(
+        domain: "WifiCaptureExtension",
+        code: -1,
+        userInfo: [NSLocalizedDescriptionKey: "Invalid UDP port"]
+      )
       completionHandler(error)
       return
     }
 
-    let networkSettings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
-    networkSettings.ipv4Settings = NEIPv4Settings(addresses: ["192.168.200.1"], subnetMasks: ["255.255.255.0"])
-    networkSettings.ipv4Settings?.includedRoutes = [NEIPv4Route.default()]
-    networkSettings.mtu = 1500
+    let filter = (configuration["filter"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    filterData = filter.isEmpty ? nil : filter.data(using: .utf8)
 
-    setTunnelNetworkSettings(networkSettings) { [weak self] error in
+    let settings = createTunnelSettings()
+    setTunnelNetworkSettings(settings) { [weak self] error in
       guard let self else { return }
       if let error {
+        self.logger.error("Failed to set tunnel settings: \(error.localizedDescription, privacy: .public)")
         completionHandler(error)
         return
       }
 
-      self.stats = CaptureStats()
-      self.readPackets(filter: filter)
-      completionHandler(nil)
-    }
-  }
+      self.startUdpConnection(port: port) { connectionError in
+        if let connectionError {
+          self.logger.error("Failed to start UDP connection: \(connectionError.localizedDescription, privacy: .public)")
+          completionHandler(connectionError)
+          return
+        }
 
-  private func readPackets(filter: String) {
-    packetFlow.readPacketObjects { [weak self] packetObjects in
-      guard let self else { return }
-      guard !packetObjects.isEmpty else {
-        self.readPackets(filter: filter)
-        return
+        self.stats = CaptureStats()
+        self.readPackets()
+        completionHandler(nil)
       }
-
-      let filterData = filter.isEmpty ? nil : Data(filter.utf8)
-
-      for packet in packetObjects {
-        let data = packet.data
-        if data.isEmpty {
-          self.stats.dropped += 1
-          continue
-        }
-
-        if let filterData, data.range(of: filterData) == nil {
-          self.stats.dropped += 1
-          continue
-        }
-
-        let parsed = PacketParser.parse(data)
-        var headers = parsed["headers"] as? [String: Any] ?? [:]
-        headers["length"] = data.count
-        let preview = parsed["preview"] as? String ?? ""
-
-        let message: [String: Any] = [
-          "id": UUID().uuidString,
-          "timestamp": Date().timeIntervalSince1970 * 1000,
-          "payload": data.base64EncodedString(),
-          "headers": headers,
-          "preview": preview,
-        ]
-
-        do {
-          let payload = try JSONSerialization.data(withJSONObject: message, options: [])
-          udpProxy?.forward(data: payload)
-          stats.bytesCaptured += UInt64(data.count)
-          stats.packetsProcessed += 1
-        } catch {
-          logger.error("Failed to serialize packet: \(error.localizedDescription, privacy: .public)")
-          stats.dropped += 1
-        }
-      }
-
-      self.readPackets(filter: filter)
     }
   }
 
   override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
     udpProxy?.stop()
     udpProxy = nil
-    completionHandler()
+    filterData = nil
+    super.stopTunnel(with: reason, completionHandler: completionHandler)
+  }
+
+  private func createTunnelSettings() -> NEPacketTunnelNetworkSettings {
+    let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
+    settings.mtu = 1500
+
+    let ipv4Settings = NEIPv4Settings(addresses: ["192.168.150.1"], subnetMasks: ["255.255.255.0"])
+    ipv4Settings.includedRoutes = [NEIPv4Route.default()]
+    settings.ipv4Settings = ipv4Settings
+
+    return settings
+  }
+
+  private func startUdpConnection(port: NWEndpoint.Port, completion: @escaping (Error?) -> Void) {
+    let proxy = UDPProxy()
+    do {
+      try proxy.start(host: "127.0.0.1", port: port.rawValue, queue: DispatchQueue.global(qos: .utility))
+      udpProxy = proxy
+      completion(nil)
+    } catch {
+      completion(error)
+    }
+  }
+
+  private func readPackets() {
+    packetFlow.readPackets { [weak self] packets, _, error in
+      guard let self else { return }
+
+      if let error {
+        self.logger.error("Failed to read packets: \(error.localizedDescription, privacy: .public)")
+        return
+      }
+
+      guard !packets.isEmpty else {
+        self.readPackets()
+        return
+      }
+
+      for packet in packets {
+        self.handle(packet: packet)
+      }
+
+      self.readPackets()
+    }
+  }
+
+  private func handle(packet: Data) {
+    guard !packet.isEmpty else {
+      stats.dropped += 1
+      return
+    }
+
+    if let filterData, packet.range(of: filterData) == nil {
+      stats.dropped += 1
+      return
+    }
+
+    let parsed = PacketParser.parse(packet)
+    var headers = (parsed["headers"] as? [String: Any]) ?? [:]
+    headers["length"] = packet.count
+    let preview = parsed["preview"] as? String ?? ""
+
+    let message: [String: Any] = [
+      "id": UUID().uuidString,
+      "timestamp": Date().timeIntervalSince1970 * 1000,
+      "payload": packet.base64EncodedString(),
+      "headers": headers,
+      "preview": preview,
+    ]
+
+    do {
+      let payload = try JSONSerialization.data(withJSONObject: message, options: [])
+      udpProxy?.send(data: payload) { [weak self] error in
+        if let error {
+          self?.logger.error("Failed to send packet: \(error.localizedDescription, privacy: .public)")
+        }
+      }
+      stats.bytesCaptured += UInt64(packet.count)
+      stats.packetsProcessed += 1
+    } catch {
+      logger.error("Failed to serialize packet: \(error.localizedDescription, privacy: .public)")
+      stats.dropped += 1
+    }
   }
 }
 

--- a/wifi-handshake-c/ios/WifiCaptureExtension/PacketTunnelProvider.swift
+++ b/wifi-handshake-c/ios/WifiCaptureExtension/PacketTunnelProvider.swift
@@ -82,13 +82,8 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
   }
 
   private func readPackets() {
-    packetFlow.readPackets { [weak self] packets, _, error in
+    packetFlow.readPackets { [weak self] packets, _ in
       guard let self else { return }
-
-      if let error {
-        self.logger.error("Failed to read packets: \(error.localizedDescription, privacy: .public)")
-        return
-      }
 
       guard !packets.isEmpty else {
         self.readPackets()

--- a/wifi-handshake-c/ios/WifiCaptureExtension/PacketTunnelProvider.swift
+++ b/wifi-handshake-c/ios/WifiCaptureExtension/PacketTunnelProvider.swift
@@ -14,6 +14,8 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
       let provider = protocolConfiguration as? NETunnelProviderProtocol,
       let configuration = provider.providerConfiguration,
       let portValue = configuration["udpPort"] as? Int,
+      portValue > 0,
+      portValue <= Int(UInt16.max),
       let port = NWEndpoint.Port(rawValue: UInt16(portValue))
     else {
       logger.error("Invalid UDP port in configuration")

--- a/wifi-handshake-c/ios/WifiCaptureExtension/WifiCaptureExtension.entitlements
+++ b/wifi-handshake-c/ios/WifiCaptureExtension/WifiCaptureExtension.entitlements
@@ -6,9 +6,5 @@
     <array>
       <string>packet-tunnel-provider</string>
     </array>
-    <key>com.apple.security.application-groups</key>
-    <array>
-      <string>group.com.yourapp.wificapture</string>
-    </array>
   </dict>
 </plist>

--- a/wifi-handshake-c/package.json
+++ b/wifi-handshake-c/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
+    "ios:build": "cd ios && xcodebuild -workspace WiFiHandshakeCapture.xcworkspace -scheme WiFiHandshakeCapture -configuration Debug -sdk iphonesimulator",
     "start": "react-native start",
     "test": "jest",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --config .eslintrc.js . --ext .ts,.tsx",

--- a/wifi-handshake-c/specs/WifiCaptureSpec.ts
+++ b/wifi-handshake-c/specs/WifiCaptureSpec.ts
@@ -9,7 +9,7 @@ import type {
   DeepCaptureOptions,
   PacketData,
   WiFiCaptureNativeModule,
-} from '@/types/WiFiSniffer';
+} from '../src/types/WiFiSniffer';
 
 export type DeepPacketEvent = PacketData;
 
@@ -67,10 +67,8 @@ const createFallbackModule = (): Spec => ({
   addListener(eventName: string) {
     fallbackEmitter.addListener(eventName, () => undefined);
   },
-  removeListeners(count: number) {
-    for (let index = 0; index < count; index += 1) {
-      fallbackEmitter.removeAllListeners('onDeepPacket');
-    }
+  removeListeners(_count: number) {
+    fallbackEmitter.removeAllListeners('onDeepPacket');
   },
 });
 
@@ -87,6 +85,6 @@ export type {
   CaptureStatistics,
   DeepCaptureOptions,
   StartDeepCaptureResult,
-} from '@/types/WiFiSniffer';
+} from '../src/types/WiFiSniffer';
 
 export default WifiCapture;

--- a/wifi-handshake-c/specs/WifiCaptureSpec.ts
+++ b/wifi-handshake-c/specs/WifiCaptureSpec.ts
@@ -5,46 +5,15 @@ import {
   Platform,
   TurboModuleRegistry,
 } from 'react-native';
+import type {
+  DeepCaptureOptions,
+  PacketData,
+  WiFiCaptureNativeModule,
+} from '@/types/WiFiSniffer';
 
-export interface DeepCaptureOptions {
-  udpPort: number;
-  filter?: string;
-}
+export type DeepPacketEvent = PacketData;
 
-export interface CaptureStatistics {
-  bytesCaptured: number;
-  packetsProcessed: number;
-  dropped: number;
-}
-
-export interface StartDeepCaptureResult {
-  sessionId: string;
-}
-
-export type DeepPacketEvent = {
-  id: string;
-  timestamp: number;
-  payload: string;
-  headers: Record<string, unknown>;
-  preview?: string;
-};
-
-export interface Spec extends TurboModule {
-  // Legacy surface
-  scan: () => Promise<Array<Record<string, unknown>>>;
-  start: (interfaceName: string) => Promise<boolean>;
-  stop: () => Promise<boolean>;
-  deauth: (bssid: string, channel: number) => Promise<boolean>;
-
-  // Deep mode APIs
-  startDeepCapture: (
-    options: DeepCaptureOptions
-  ) => Promise<StartDeepCaptureResult>;
-  stopDeepCapture: (sessionId: string) => Promise<void>;
-  getCaptureStats: (sessionId: string) => Promise<CaptureStatistics>;
-  addListener: (eventName: string) => void;
-  removeListeners: (count: number) => void;
-}
+export type Spec = TurboModule & WiFiCaptureNativeModule;
 
 const LINKING_ERROR =
   "The native module 'WifiCapture' is not linked. Ensure pods are installed and that the app was rebuilt.";
@@ -78,18 +47,18 @@ const createFallbackModule = (): Spec => ({
     }
     return false;
   },
-  async startDeepCapture() {
+  async startDeepCapture(_options: DeepCaptureOptions) {
     if (Platform.OS === 'ios') {
       console.warn(`[WifiCapture] ${LINKING_ERROR}`);
     }
     return { sessionId: 'fallback' };
   },
-  async stopDeepCapture() {
+  async stopDeepCapture(_sessionId: string) {
     if (Platform.OS === 'ios') {
       console.warn(`[WifiCapture] ${LINKING_ERROR}`);
     }
   },
-  async getCaptureStats() {
+  async getCaptureStats(_sessionId: string) {
     if (Platform.OS === 'ios') {
       console.warn(`[WifiCapture] ${LINKING_ERROR}`);
     }
@@ -113,5 +82,11 @@ export const WifiCaptureEvents = nativeModule
         (nativeModule as unknown as object)
     )
   : fallbackEmitter;
+
+export type {
+  CaptureStatistics,
+  DeepCaptureOptions,
+  StartDeepCaptureResult,
+} from '@/types/WiFiSniffer';
 
 export default WifiCapture;

--- a/wifi-handshake-c/specs/__tests__/WifiCaptureSpec.test.ts
+++ b/wifi-handshake-c/specs/__tests__/WifiCaptureSpec.test.ts
@@ -1,0 +1,122 @@
+jest.mock('react-native', () => {
+  const EventEmitter = require('events');
+
+  class MockNativeEventEmitter {
+    private readonly emitter = new EventEmitter();
+
+    constructor(_nativeModule?: unknown) {}
+
+    addListener(eventName: string, listener: (...args: unknown[]) => void) {
+      this.emitter.on(eventName, listener);
+      return {
+        remove: () => this.emitter.removeListener(eventName, listener),
+      };
+    }
+
+    removeAllListeners(eventName: string) {
+      this.emitter.removeAllListeners(eventName);
+    }
+
+    emit(eventName: string, ...args: unknown[]) {
+      this.emitter.emit(eventName, ...args);
+    }
+  }
+
+  const nativeModules: Record<string, unknown> = {};
+  const turboModuleRegistry = {
+    get: jest.fn(),
+  };
+
+  return {
+    NativeModules: nativeModules,
+    TurboModuleRegistry: turboModuleRegistry,
+    NativeEventEmitter: MockNativeEventEmitter,
+    Platform: { OS: 'ios' },
+  };
+});
+
+import type { Spec } from '../WifiCaptureSpec';
+
+const { NativeModules, TurboModuleRegistry } = require('react-native');
+
+const createNativeModule = () => ({
+  scan: jest.fn().mockResolvedValue([
+    {
+      ssid: 'TestNetwork',
+      bssid: '00:11:22:33:44:55',
+      signal: -45,
+      channel: 6,
+      frequency: 2437,
+      security: 'WPA2',
+    },
+  ]),
+  start: jest.fn(),
+  stop: jest.fn(),
+  deauth: jest.fn(),
+  startDeepCapture: jest.fn().mockResolvedValue({ sessionId: 'session-1' }),
+  stopDeepCapture: jest.fn(),
+  getCaptureStats: jest.fn().mockResolvedValue({
+    bytesCaptured: 1024,
+    packetsProcessed: 50,
+    dropped: 1,
+  }),
+  addListener: jest.fn(),
+  removeListeners: jest.fn(),
+});
+
+describe('WifiCaptureSpec', () => {
+  afterEach(() => {
+    delete NativeModules.WifiCapture;
+    (TurboModuleRegistry.get as jest.Mock).mockReset();
+  });
+
+  it('scans for networks', async () => {
+    const nativeModule = createNativeModule();
+    (TurboModuleRegistry.get as jest.Mock).mockReturnValue(nativeModule);
+    NativeModules.WifiCapture = nativeModule;
+
+    let WifiCapture: Spec;
+    jest.isolateModules(() => {
+      const module = require('../WifiCaptureSpec');
+      WifiCapture = module.default;
+    });
+
+    const networks = await WifiCapture.scan();
+    expect(nativeModule.scan).toHaveBeenCalled();
+    expect(networks).toEqual([
+      expect.objectContaining({
+        ssid: 'TestNetwork',
+        bssid: '00:11:22:33:44:55',
+        signal: -45,
+        channel: 6,
+        frequency: 2437,
+        security: 'WPA2',
+      }),
+    ]);
+  });
+
+  it('rejects on invalid port for deep capture', async () => {
+    const nativeModule = createNativeModule();
+    nativeModule.startDeepCapture = jest
+      .fn()
+      .mockImplementation(async (options) => {
+        if (!options || options.udpPort === undefined || options.udpPort <= 0) {
+          throw new Error('INVALID_PORT');
+        }
+        return { sessionId: 'valid-session' };
+      });
+
+    (TurboModuleRegistry.get as jest.Mock).mockReturnValue(nativeModule);
+    NativeModules.WifiCapture = nativeModule;
+
+    let WifiCapture: Spec;
+    jest.isolateModules(() => {
+      const module = require('../WifiCaptureSpec');
+      WifiCapture = module.default;
+    });
+
+    await expect(WifiCapture.startDeepCapture({ udpPort: -1 })).rejects.toThrow(
+      'INVALID_PORT'
+    );
+  });
+});

--- a/wifi-handshake-c/src/deepcapture/components/PacketItem.tsx
+++ b/wifi-handshake-c/src/deepcapture/components/PacketItem.tsx
@@ -25,6 +25,11 @@ const PacketItem: React.FC<PacketItemProps> = React.memo(({ packet }) => {
         {packet.preview}
       </Text>
       <Text style={styles.type}>Type: {type}</Text>
+      {packet.isHandshake ? (
+        <View style={styles.badge}>
+          <Text style={styles.badgeText}>Handshake</Text>
+        </View>
+      ) : null}
     </View>
   );
 });
@@ -54,5 +59,18 @@ const styles = StyleSheet.create({
     marginTop: 6,
     fontSize: 12,
     color: '#636366',
+  },
+  badge: {
+    alignSelf: 'flex-start',
+    marginTop: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 12,
+    backgroundColor: '#34C75933',
+  },
+  badgeText: {
+    fontSize: 11,
+    color: '#34C759',
+    fontWeight: '600',
   },
 });

--- a/wifi-handshake-c/src/deepcapture/hooks/usePackets.ts
+++ b/wifi-handshake-c/src/deepcapture/hooks/usePackets.ts
@@ -1,11 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { NativeEventEmitter, NativeModules } from 'react-native';
 import { decode } from 'base64-arraybuffer';
-import WifiCapture, {
-  WifiCaptureEvents,
-  type DeepPacketEvent,
-} from 'specs/WifiCaptureSpec';
-import { parsePacket as parseDeepPacket } from '@/services/PacketParserService';
+import { WifiCaptureEvents, type DeepPacketEvent } from 'specs/WifiCaptureSpec';
+import { parsePacket as parseDeepPacket } from '../../services/PacketParserService';
 
 export interface PacketPreview {
   id: string;
@@ -124,17 +121,10 @@ export const usePackets = (sessionId: string | null): UsePacketsResult => {
       ? new NativeEventEmitter(nativeModule)
       : WifiCaptureEvents;
 
-    if (typeof WifiCapture.addListener === 'function') {
-      WifiCapture.addListener('onDeepPacket');
-    }
-
     const subscription = emitter.addListener('onDeepPacket', ingest);
 
     return () => {
       subscription.remove();
-      if (typeof WifiCapture.removeListeners === 'function') {
-        WifiCapture.removeListeners(1);
-      }
     };
   }, [ingest, sessionId]);
 

--- a/wifi-handshake-c/src/deepcapture/hooks/usePackets.ts
+++ b/wifi-handshake-c/src/deepcapture/hooks/usePackets.ts
@@ -113,9 +113,12 @@ export const usePackets = (sessionId: string | null): UsePacketsResult => {
       return undefined;
     }
 
-    const nativeModule = NativeModules.WifiCapture as
-      | Record<string, unknown>
-      | undefined;
+    const nativeModule =
+      typeof NativeModules !== 'undefined' && NativeModules != null
+        ? ((NativeModules as Record<string, unknown>).WifiCapture as
+            | Record<string, unknown>
+            | undefined)
+        : undefined;
     const hasNativeModule = Boolean(nativeModule);
     const emitter = hasNativeModule
       ? new NativeEventEmitter(nativeModule)
@@ -131,9 +134,6 @@ export const usePackets = (sessionId: string | null): UsePacketsResult => {
       subscription.remove();
       if (typeof WifiCapture.removeListeners === 'function') {
         WifiCapture.removeListeners(1);
-      }
-      if (hasNativeModule) {
-        (emitter as NativeEventEmitter).removeAllListeners('onDeepPacket');
       }
     };
   }, [ingest, sessionId]);

--- a/wifi-handshake-c/src/types/WiFiSniffer.ts
+++ b/wifi-handshake-c/src/types/WiFiSniffer.ts
@@ -154,6 +154,43 @@ export const WiFiSnifferEvents = new NativeEventEmitter(
 
 export const isWiFiSnifferAvailable = Boolean(nativeModule);
 
+export interface PacketData {
+  id: string;
+  timestamp: number;
+  payload: string;
+  headers: Record<string, unknown>;
+  preview: string;
+}
+
+export interface DeepCaptureOptions {
+  udpPort?: number;
+  filter?: string;
+}
+
+export interface StartDeepCaptureResult {
+  sessionId: string;
+}
+
+export interface CaptureStatistics {
+  bytesCaptured: number;
+  packetsProcessed: number;
+  dropped: number;
+}
+
+export interface WiFiCaptureNativeModule {
+  scan(): Promise<Array<Record<string, unknown>>>;
+  start(interfaceName: string): Promise<boolean>;
+  stop(): Promise<boolean>;
+  deauth(bssid: string, channel: number): Promise<boolean>;
+  startDeepCapture(
+    options: DeepCaptureOptions
+  ): Promise<StartDeepCaptureResult>;
+  stopDeepCapture(sessionId: string): Promise<void>;
+  getCaptureStats(sessionId: string): Promise<CaptureStatistics>;
+  addListener(eventName: 'onDeepPacket'): void;
+  removeListeners(count: number): void;
+}
+
 export default WiFiSniffer;
 
 export type { HandshakePacket as WiFiHandshakePacket };


### PR DESCRIPTION
## Summary
- add retry logic, timeout handling, and dynamic bundle resolution to `WifiCaptureImpl`
- rebuild the packet tunnel provider, UDP proxy, and entitlements for the Network Extension
- extend TypeScript definitions, packet handling, and UI to surface handshake packets and add Jest coverage
- document local iOS build steps and expose an `ios:build` npm script

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3292e32f48333992f64b4f524af6e

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/prREVIEW/57)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Packet list shows a “Handshake” badge; packet parsing now detects handshakes.
  * Deep capture APIs now accept options and use session-scoped stats.

* Refactor
  * More reliable iOS tunnel startup with retry/backoff and improved extension packet/UDP flow.
  * UDP proxy and per-packet processing streamlined.

* Documentation
  * Added guide to run a local iOS build without signing.

* Chores
  * Added ios:build script; simplified iOS app capabilities for simulator use.

* Tests
  * Added WiFiCapture spec and packet hook tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->