### PR TITLE
Enhance capture metadata and tunnel diagnostics

### DIFF
--- a/wifi-handshake-c/ios/WifiCapture/PacketParser.mm
+++ b/wifi-handshake-c/ios/WifiCapture/PacketParser.mm
@@ -4,6 +4,7 @@
 #include <arpa/inet.h>
 #include <iomanip>
 #include <sstream>
+#include <vector>
 
 #pragma pack(push, 1)
 struct RadiotapHeader {
@@ -34,6 +35,163 @@ static NSString *TypeString(uint8_t type, uint8_t subtype) {
     default:
       return [NSString stringWithFormat:@"Reserved subtype %u", subtype];
   }
+}
+
+static NSString *FrameCategoryString(uint8_t type) {
+  switch (type) {
+    case 0:
+      return @"Management";
+    case 1:
+      return @"Control";
+    case 2:
+      return @"Data";
+    default:
+      return @"Reserved";
+  }
+}
+
+static NSString *HexString(const uint8_t *data, size_t length) {
+  if (length == 0 || data == nullptr) {
+    return @"";
+  }
+
+  std::ostringstream stream;
+  stream << std::hex << std::setfill('0');
+  for (size_t index = 0; index < length; index++) {
+    stream << std::setw(2) << static_cast<int>(data[index]);
+  }
+  return [NSString stringWithUTF8String:stream.str().c_str()];
+}
+
+static size_t AlignOffset(size_t offset, size_t alignment) {
+  if (alignment == 0) {
+    return offset;
+  }
+  const size_t remainder = offset % alignment;
+  if (remainder == 0) {
+    return offset;
+  }
+  return offset + (alignment - remainder);
+}
+
+struct FieldLayout {
+  size_t length;
+  size_t alignment;
+};
+
+static FieldLayout FieldLayoutForBit(size_t bitIndex) {
+  switch (bitIndex) {
+    case 0:
+      return {8, 8};
+    case 1:
+      return {1, 1};
+    case 2:
+      return {1, 1};
+    case 3:
+      return {4, 2};
+    case 4:
+      return {2, 2};
+    case 5:
+      return {1, 1};
+    case 6:
+      return {1, 1};
+    case 7:
+      return {2, 2};
+    case 8:
+      return {2, 2};
+    case 9:
+      return {2, 2};
+    case 10:
+      return {1, 1};
+    case 11:
+      return {1, 1};
+    case 12:
+      return {1, 1};
+    case 13:
+      return {1, 1};
+    case 14:
+      return {2, 2};
+    case 15:
+      return {2, 2};
+    case 16:
+      return {1, 1};
+    case 17:
+      return {1, 1};
+    case 18:
+      return {8, 8};
+    case 19:
+      return {3, 1};
+    case 20:
+      return {8, 8};
+    case 21:
+      return {2, 2};
+    case 22:
+      return {2, 2};
+    case 23:
+      return {4, 4};
+    case 24:
+      return {1, 1};
+    case 25:
+      return {1, 1};
+    case 26:
+      return {1, 1};
+    case 27:
+      return {1, 1};
+    case 28:
+      return {8, 8};
+    case 29:
+      return {8, 8};
+    case 30:
+      return {8, 8};
+    default:
+      return {0, 1};
+  }
+}
+
+static NSInteger ChannelForFrequency(uint16_t frequency) {
+  if (frequency == 0) {
+    return 0;
+  }
+
+  if (frequency == 2484) {
+    return 14;
+  }
+
+  if (frequency >= 2412 && frequency <= 2472) {
+    return (frequency - 2407) / 5;
+  }
+
+  if (frequency >= 5000 && frequency <= 5895) {
+    return (frequency - 5000) / 5;
+  }
+
+  if (frequency >= 5925 && frequency <= 7125) {
+    if (frequency < 5955) {
+      return 0;
+    }
+    return static_cast<NSInteger>((frequency - 5955) / 5 + 1);
+  }
+
+  return 0;
+}
+
+static NSInteger DetermineEapolMessage(uint16_t keyInfo) {
+  const uint16_t infoMask = keyInfo & 0x000f;
+  const bool ack = (keyInfo & 0x0010) != 0;
+
+  if (infoMask == 0x0008 && ack) {
+    return 1;
+  }
+  if (infoMask == 0x0009 && !ack) {
+    return 2;
+  }
+  if (infoMask == 0x0009 && ack) {
+    return 3;
+  }
+  if (infoMask == 0x000b && !ack) {
+    return 4;
+  }
+  return 0;
 }
 
 static NSString *ProtocolString(uint8_t protocol) {
@@ -202,6 +360,82 @@ static NSDictionary<NSString *, id> *ParseIPv6Packet(const uint8_t *bytes, size_
     return @{ "headers": @{}, "preview": @"" };
   }
 
+  std::vector<uint32_t> presentWords;
+  presentWords.reserve(4);
+  uint32_t presentWord = CFSwapInt32LittleToHost(radiotap->presentFlags);
+  presentWords.push_back(presentWord);
+
+  size_t offset = sizeof(RadiotapHeader);
+  while ((presentWord & 0x80000000) != 0 && offset + sizeof(uint32_t) <= radiotapLength) {
+    presentWord = CFSwapInt32LittleToHost(
+      *reinterpret_cast<const uint32_t *>(bytes + offset)
+    );
+    presentWords.push_back(presentWord);
+    offset += sizeof(uint32_t);
+  }
+
+  size_t fieldOffset = offset;
+  uint16_t channelFrequency = 0;
+  uint16_t channelFlags = 0;
+  int8_t signalStrength = 0;
+  int8_t noiseLevel = 0;
+  bool hasSignal = false;
+  bool hasNoise = false;
+  uint64_t presentMask = 0;
+
+  for (size_t wordIndex = 0; wordIndex < presentWords.size(); wordIndex++) {
+    const uint32_t wordValue = presentWords[wordIndex];
+    if (wordIndex < 2) {
+      presentMask |= static_cast<uint64_t>(wordValue) << (wordIndex * 32);
+    }
+
+    for (size_t bitIndex = 0; bitIndex < 32; bitIndex++) {
+      if ((wordValue & (1u << bitIndex)) == 0) {
+        continue;
+      }
+
+      const size_t globalBitIndex = wordIndex * 32 + bitIndex;
+      const FieldLayout layout = FieldLayoutForBit(globalBitIndex);
+      if (layout.length == 0) {
+        continue;
+      }
+
+      fieldOffset = AlignOffset(fieldOffset, layout.alignment);
+      if (fieldOffset + layout.length > radiotapLength) {
+        fieldOffset = radiotapLength;
+        continue;
+      }
+
+      const uint8_t *fieldPointer = bytes + fieldOffset;
+
+      switch (globalBitIndex) {
+        case 3: {
+          channelFrequency = CFSwapInt16LittleToHost(
+            *reinterpret_cast<const uint16_t *>(fieldPointer)
+          );
+          channelFlags = CFSwapInt16LittleToHost(
+            *reinterpret_cast<const uint16_t *>(fieldPointer + 2)
+          );
+          break;
+        }
+        case 5: {
+          signalStrength = static_cast<int8_t>(fieldPointer[0]);
+          hasSignal = true;
+          break;
+        }
+        case 6: {
+          noiseLevel = static_cast<int8_t>(fieldPointer[0]);
+          hasNoise = true;
+          break;
+        }
+        default:
+          break;
+      }
+
+      fieldOffset += layout.length;
+    }
+  }
+
   const size_t frameOffset = radiotapLength;
   const size_t remainingLength = data.length - frameOffset;
 
@@ -218,12 +452,37 @@ static NSDictionary<NSString *, id> *ParseIPv6Packet(const uint8_t *bytes, size_
   const bool fromDS = (frameControl & (1 << 9)) != 0;
 
   NSMutableDictionary *headers = [NSMutableDictionary dictionary];
+  headers[@"frameType"] = FrameCategoryString(type);
+  headers[@"frameSubtype"] = @(subtype);
   headers[@"type"] = TypeString(type, subtype);
   headers[@"duration"] = @(CFSwapInt16LittleToHost(header->durationId));
   headers[@"addr1"] = MacString(header->address1);
   headers[@"addr2"] = MacString(header->address2);
   headers[@"addr3"] = MacString(header->address3);
   headers[@"sequenceControl"] = @(CFSwapInt16LittleToHost(header->sequenceControl));
+  headers[@"frameControl"] = @(frameControl);
+  headers[@"packetSize"] = @(data.length);
+
+  if (channelFrequency > 0) {
+    headers[@"frequency"] = @(channelFrequency);
+    const NSInteger channelNumber = ChannelForFrequency(channelFrequency);
+    if (channelNumber > 0) {
+      headers[@"channel"] = @(channelNumber);
+    }
+    headers[@"channelFlags"] = @(channelFlags);
+  }
+
+  if (hasSignal) {
+    headers[@"signal"] = @(signalStrength);
+  }
+
+  if (hasNoise) {
+    headers[@"noise"] = @(noiseLevel);
+  }
+
+  if (presentMask != 0) {
+    headers[@"radiotapPresentFlags"] = @(static_cast<unsigned long long>(presentMask));
+  }
 
   size_t payloadOffset = frameOffset + sizeof(IEEE80211Header);
   if (toDS && fromDS) {
@@ -231,6 +490,88 @@ static NSDictionary<NSString *, id> *ParseIPv6Packet(const uint8_t *bytes, size_
       const uint8_t *addr4 = bytes + frameOffset + sizeof(IEEE80211Header);
       headers[@"addr4"] = MacString(addr4);
       payloadOffset += 6;
+    }
+  }
+
+  const size_t llcLength = 8;
+  if (type == 2 && payloadOffset + llcLength <= data.length) {
+    const uint8_t *llc = bytes + payloadOffset;
+    const bool hasSnap =
+      llc[0] == 0xaa &&
+      llc[1] == 0xaa &&
+      llc[2] == 0x03 &&
+      llc[3] == 0x00 &&
+      llc[4] == 0x00 &&
+      llc[5] == 0x00 &&
+      llc[6] == 0x88 &&
+      llc[7] == 0x8e;
+
+    if (hasSnap) {
+      const size_t eapolOffset = payloadOffset + llcLength;
+      if (eapolOffset + 4 <= data.length) {
+        const uint8_t version = bytes[eapolOffset];
+        const uint8_t eapolType = bytes[eapolOffset + 1];
+        const uint16_t eapolLength =
+          static_cast<uint16_t>(bytes[eapolOffset + 2]) << 8 |
+          static_cast<uint16_t>(bytes[eapolOffset + 3]);
+
+        if (eapolType == 0x03 && eapolOffset + 4 + eapolLength <= data.length) {
+          headers[@"type"] = @"EAPOL";
+          headers[@"isEapol"] = @YES;
+          headers[@"eapolVersion"] = @(version);
+          headers[@"eapolLength"] = @(eapolLength);
+
+          const size_t descriptorOffset = eapolOffset + 4;
+          if (eapolLength >= 95 && descriptorOffset + 95 <= eapolOffset + 4 + eapolLength) {
+            const uint8_t descriptorType = bytes[descriptorOffset];
+            const uint16_t keyInfo =
+              static_cast<uint16_t>(bytes[descriptorOffset + 1]) << 8 |
+              static_cast<uint16_t>(bytes[descriptorOffset + 2]);
+            const uint16_t keyLength =
+              static_cast<uint16_t>(bytes[descriptorOffset + 3]) << 8 |
+              static_cast<uint16_t>(bytes[descriptorOffset + 4]);
+            const uint16_t keyDataLength =
+              static_cast<uint16_t>(bytes[descriptorOffset + 93]) << 8 |
+              static_cast<uint16_t>(bytes[descriptorOffset + 94]);
+
+            headers[@"descriptorType"] = @(descriptorType);
+            headers[@"keyInfo"] = @(keyInfo);
+            headers[@"keyLength"] = @(keyLength);
+            headers[@"keyDataLength"] = @(keyDataLength);
+            headers[@"keyMicPresent"] = @((keyInfo & 0x0100) != 0);
+            headers[@"keyEncrypted"] = @((keyInfo & 0x0400) != 0);
+            headers[@"keyAck"] = @((keyInfo & 0x0010) != 0);
+            headers[@"keyDescriptorVersion"] = @((keyInfo >> 12) & 0x0003);
+
+            const NSInteger messageNumber = DetermineEapolMessage(keyInfo);
+            if (messageNumber > 0) {
+              headers[@"eapolMessage"] = @(messageNumber);
+            }
+
+            const size_t replayOffset = descriptorOffset + 5;
+            const size_t nonceOffset = descriptorOffset + 13;
+            const size_t ivOffset = descriptorOffset + 45;
+            const size_t rscOffset = descriptorOffset + 61;
+            const size_t idOffset = descriptorOffset + 69;
+            const size_t micOffset = descriptorOffset + 77;
+            const size_t keyDataOffset = descriptorOffset + 95;
+
+            headers[@"replayCounter"] = HexString(bytes + replayOffset, 8);
+            headers[@"keyNonce"] = HexString(bytes + nonceOffset, 32);
+            headers[@"keyIV"] = HexString(bytes + ivOffset, 16);
+            headers[@"keyRSC"] = HexString(bytes + rscOffset, 8);
+            headers[@"keyID"] = HexString(bytes + idOffset, 8);
+
+            if ((keyInfo & 0x0100) != 0) {
+              headers[@"keyMIC"] = HexString(bytes + micOffset, 16);
+            }
+
+            if (keyDataLength > 0 && keyDataOffset + keyDataLength <= eapolOffset + 4 + eapolLength) {
+              headers[@"keyData"] = HexString(bytes + keyDataOffset, keyDataLength);
+            }
+          }
+        }
+      }
     }
   }
 

--- a/wifi-handshake-c/ios/WifiCapture/PacketParser.mm
+++ b/wifi-handshake-c/ios/WifiCapture/PacketParser.mm
@@ -382,6 +382,9 @@ static NSDictionary<NSString *, id> *ParseIPv6Packet(const uint8_t *bytes, size_
   bool hasSignal = false;
   bool hasNoise = false;
   uint64_t presentMask = 0;
+  bool gotChannel = false;
+  bool gotSignal = false;
+  bool gotNoise = false;
 
   for (size_t wordIndex = 0; wordIndex < presentWords.size(); wordIndex++) {
     const uint32_t wordValue = presentWords[wordIndex];
@@ -416,16 +419,19 @@ static NSDictionary<NSString *, id> *ParseIPv6Packet(const uint8_t *bytes, size_
           channelFlags = CFSwapInt16LittleToHost(
             *reinterpret_cast<const uint16_t *>(fieldPointer + 2)
           );
+          gotChannel = true;
           break;
         }
         case 5: {
           signalStrength = static_cast<int8_t>(fieldPointer[0]);
           hasSignal = true;
+          gotSignal = true;
           break;
         }
         case 6: {
           noiseLevel = static_cast<int8_t>(fieldPointer[0]);
           hasNoise = true;
+          gotNoise = true;
           break;
         }
         default:
@@ -433,6 +439,12 @@ static NSDictionary<NSString *, id> *ParseIPv6Packet(const uint8_t *bytes, size_
       }
 
       fieldOffset += layout.length;
+      if (gotChannel && gotSignal && gotNoise) {
+        break;
+      }
+    }
+    if (gotChannel && gotSignal && gotNoise) {
+      break;
     }
   }
 

--- a/wifi-handshake-c/ios/WifiCaptureExtension/PacketTunnelProvider.swift
+++ b/wifi-handshake-c/ios/WifiCaptureExtension/PacketTunnelProvider.swift
@@ -2,6 +2,7 @@ import Foundation
 import Network
 import NetworkExtension
 import os.log
+import Darwin
 
 final class PacketTunnelProvider: NEPacketTunnelProvider {
   private let logger = Logger(subsystem: "WifiCaptureExtension", category: "PacketTunnelProvider")
@@ -55,10 +56,12 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
   }
 
   override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
+    logger.log("Stopping tunnel with reason: \(describe(reason: reason), privacy: .public)")
     udpProxy?.stop()
     udpProxy = nil
     filterData = nil
-    super.stopTunnel(with: reason, completionHandler: completionHandler)
+    stats.logFinalMetrics(logger: logger)
+    completionHandler()
   }
 
   private func createTunnelSettings() -> NEPacketTunnelNetworkSettings {
@@ -67,7 +70,19 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
 
     let ipv4Settings = NEIPv4Settings(addresses: ["192.168.150.1"], subnetMasks: ["255.255.255.0"])
     ipv4Settings.includedRoutes = [NEIPv4Route.default()]
+    ipv4Settings.excludedRoutes = [
+      NEIPv4Route(destinationAddress: "127.0.0.0", subnetMask: "255.0.0.0"),
+      NEIPv4Route(destinationAddress: "192.168.150.1", subnetMask: "255.255.255.255"),
+    ]
     settings.ipv4Settings = ipv4Settings
+
+    let ipv6Settings = NEIPv6Settings(addresses: ["fd00:1:1::1"], networkPrefixLengths: [64])
+    ipv6Settings.includedRoutes = [NEIPv6Route.default()]
+    ipv6Settings.excludedRoutes = [
+      NEIPv6Route(destinationAddress: "::1", networkPrefixLength: 128),
+      NEIPv6Route(destinationAddress: "fe80::", networkPrefixLength: 10),
+    ]
+    settings.ipv6Settings = ipv6Settings
 
     return settings
   }
@@ -84,7 +99,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
   }
 
   private func readPackets() {
-    packetFlow.readPackets { [weak self] packets, _ in
+    packetFlow.readPackets { [weak self] packets, protocols in
       guard let self else { return }
 
       guard !packets.isEmpty else {
@@ -92,15 +107,21 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
         return
       }
 
-      for packet in packets {
-        self.handle(packet: packet)
+      for (index, packet) in packets.enumerated() {
+        let protocolNumber: NSNumber?
+        if let protocols, index < protocols.count {
+          protocolNumber = protocols[index]
+        } else {
+          protocolNumber = nil
+        }
+        self.handle(packet: packet, protocolNumber: protocolNumber)
       }
 
       self.readPackets()
     }
   }
 
-  private func handle(packet: Data) {
+  private func handle(packet: Data, protocolNumber: NSNumber?) {
     guard !packet.isEmpty else {
       stats.dropped += 1
       return
@@ -114,6 +135,10 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
     let parsed = PacketParser.parseIPPacket(packet)
     var headers = (parsed["headers"] as? [String: Any]) ?? [:]
     headers["length"] = packet.count
+    headers["packetSize"] = packet.count
+    if let protocolNumber {
+      headers["protocolFamily"] = protocolFamilyString(for: protocolNumber.intValue)
+    }
     let preview = parsed["preview"] as? String ?? PacketParser.hexPreview(for: packet)
 
     let message: [String: Any] = [
@@ -138,10 +163,78 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
       stats.dropped += 1
     }
   }
+
+  private func protocolFamilyString(for value: Int) -> String {
+    switch value {
+    case AF_INET:
+      return "AF_INET"
+    case AF_INET6:
+      return "AF_INET6"
+    default:
+      return "AF_OTHER"
+    }
+  }
+
+  private func describe(reason: NEProviderStopReason) -> String {
+    switch reason {
+    case .none:
+      return "none"
+    case .userInitiated:
+      return "userInitiated"
+    case .providerFailed:
+      return "providerFailed"
+    case .noNetworkAvailable:
+      return "noNetworkAvailable"
+    case .unrecoverableNetworkChange:
+      return "unrecoverableNetworkChange"
+    case .providerDisabled:
+      return "providerDisabled"
+    case .authenticationCanceled:
+      return "authenticationCanceled"
+    case .configurationFailed:
+      return "configurationFailed"
+    case .idleTimeout:
+      return "idleTimeout"
+    case .configurationDisabled:
+      return "configurationDisabled"
+    case .configurationRemoved:
+      return "configurationRemoved"
+    case .superceded:
+      return "superceded"
+    case .userLogout:
+      return "userLogout"
+    case .userSwitch:
+      return "userSwitch"
+    case .connectionFailed:
+      return "connectionFailed"
+    case .sleep:
+      return "sleep"
+    case .appUpdate:
+      return "appUpdate"
+    case .permissionRevoked:
+      return "permissionRevoked"
+    case .airplaneMode:
+      return "airplaneMode"
+    @unknown default:
+      return "unknown_\(reason.rawValue)"
+    }
+  }
 }
 
 private struct CaptureStats {
   var bytesCaptured: UInt64 = 0
   var packetsProcessed: UInt64 = 0
   var dropped: UInt64 = 0
+
+  mutating func reset() {
+    bytesCaptured = 0
+    packetsProcessed = 0
+    dropped = 0
+  }
+
+  func logFinalMetrics(logger: Logger) {
+    logger.log(
+      "Capture summary packets=\(packetsProcessed, privacy: .public) bytes=\(bytesCaptured, privacy: .public) dropped=\(dropped, privacy: .public)"
+    )
+  }
 }

--- a/wifi-handshake-c/ios/WifiCaptureExtension/PacketTunnelProvider.swift
+++ b/wifi-handshake-c/ios/WifiCaptureExtension/PacketTunnelProvider.swift
@@ -109,7 +109,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider {
 
       for (index, packet) in packets.enumerated() {
         let protocolNumber: NSNumber?
-        if let protocols, index < protocols.count {
+        if index < protocols.count {
           protocolNumber = protocols[index]
         } else {
           protocolNumber = nil

--- a/wifi-handshake-c/package-lock.json
+++ b/wifi-handshake-c/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.19.3",
+        "@react-native/babel-preset": "^0.81.1",
         "@react-navigation/native": "^6.1.18",
         "@react-navigation/native-stack": "^6.11.0",
         "base64-arraybuffer": "^1.0.2",
@@ -30,7 +31,6 @@
         "@babel/core": "^7.20.0",
         "@babel/preset-env": "^7.20.0",
         "@babel/runtime": "^7.20.0",
-        "@react-native/babel-preset": "^0.81.1",
         "@react-native/eslint-config": "^0.72.2",
         "@react-native/metro-config": "^0.72.11",
         "@tsconfig/react-native": "^3.0.0",
@@ -3110,7 +3110,6 @@
       "version": "0.81.1",
       "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.1.tgz",
       "integrity": "sha512-cxYq78YePcIX2871UiEItG7ibk+GeXRr7A3ZR2DN4fZ7X4An/734DwLVop/CcHpK3Ycr0Re8FKEVTcJRiVb1zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
@@ -3124,7 +3123,6 @@
       "version": "0.81.1",
       "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.81.1.tgz",
       "integrity": "sha512-8KoUE1j65fF1PPHlAhSeUHmcyqpE+Z7Qv27A89vSZkz3s8eqWSRu2hZtCl0D3nSgS0WW0fyrIsFaRFj7azIiPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -3146,14 +3144,12 @@
       "version": "0.29.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
       "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@react-native/babel-plugin-codegen/node_modules/hermes-parser": {
       "version": "0.29.1",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
       "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.29.1"
@@ -3163,7 +3159,6 @@
       "version": "0.81.1",
       "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.81.1.tgz",
       "integrity": "sha512-dCxb4AdaoLZipfKNEpO70WK7cxbTsq62dzK2EuFta65WJO/K7+sMoF8V6P0MKfCaHwj/1Va2rp/LKtHd9ttPVw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -3223,7 +3218,6 @@
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5142,7 +5136,6 @@
       "version": "0.29.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.29.1.tgz",
       "integrity": "sha512-2WFYnoWGdmih1I1J5eIqxATOeycOqRwYxAQBu3cUu/rhwInwHUg7k60AFNbuGjSDL8tje5GDrAnxzRLcu2pYcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hermes-parser": "0.29.1"
@@ -5152,14 +5145,12 @@
       "version": "0.29.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
       "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-parser": {
       "version": "0.29.1",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
       "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.29.1"

--- a/wifi-handshake-c/package-lock.json
+++ b/wifi-handshake-c/package-lock.json
@@ -30,7 +30,7 @@
         "@babel/core": "^7.20.0",
         "@babel/preset-env": "^7.20.0",
         "@babel/runtime": "^7.20.0",
-        "@react-native/babel-preset": "^0.76.7",
+        "@react-native/babel-preset": "^0.81.1",
         "@react-native/eslint-config": "^0.72.2",
         "@react-native/metro-config": "^0.72.11",
         "@tsconfig/react-native": "^3.0.0",
@@ -3107,62 +3107,62 @@
       "license": "MIT"
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.76.9",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.9.tgz",
-      "integrity": "sha512-vxL/vtDEIYHfWKm5oTaEmwcnNGsua/i9OjIxBDBFiJDu5i5RU3bpmDiXQm/bJxrJNPRp5lW0I0kpGihVhnMAIQ==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.1.tgz",
+      "integrity": "sha512-cxYq78YePcIX2871UiEItG7ibk+GeXRr7A3ZR2DN4fZ7X4An/734DwLVop/CcHpK3Ycr0Re8FKEVTcJRiVb1zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@react-native/codegen": "0.76.9"
+        "@babel/traverse": "^7.25.3",
+        "@react-native/codegen": "0.81.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/babel-plugin-codegen/node_modules/@react-native/codegen": {
-      "version": "0.76.9",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.76.9.tgz",
-      "integrity": "sha512-AzlCHMTKrAVC2709V4ZGtBXmGVtWTpWm3Ruv5vXcd3/anH4mGucfJ4rjbWKdaYQJMpXa3ytGomQrsIsT/s8kgA==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.81.1.tgz",
+      "integrity": "sha512-8KoUE1j65fF1PPHlAhSeUHmcyqpE+Z7Qv27A89vSZkz3s8eqWSRu2hZtCl0D3nSgS0WW0fyrIsFaRFj7azIiPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@babel/core": "^7.25.2",
         "@babel/parser": "^7.25.3",
         "glob": "^7.1.1",
-        "hermes-parser": "0.23.1",
+        "hermes-parser": "0.29.1",
         "invariant": "^2.2.4",
-        "jscodeshift": "^0.14.0",
-        "mkdirp": "^0.5.1",
         "nullthrows": "^1.1.1",
         "yargs": "^17.6.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "@babel/preset-env": "^7.1.6"
+        "@babel/core": "*"
       }
     },
     "node_modules/@react-native/babel-plugin-codegen/node_modules/hermes-estree": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.1.tgz",
-      "integrity": "sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@react-native/babel-plugin-codegen/node_modules/hermes-parser": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.1.tgz",
-      "integrity": "sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.23.1"
+        "hermes-estree": "0.29.1"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.76.9",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.76.9.tgz",
-      "integrity": "sha512-TbSeCplCM6WhL3hR2MjC/E1a9cRnMLz7i767T7mP90oWkklEjyPxWl+0GGoVGnJ8FC/jLUupg/HvREKjjif6lw==",
+      "version": "0.81.1",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.81.1.tgz",
+      "integrity": "sha512-dCxb4AdaoLZipfKNEpO70WK7cxbTsq62dzK2EuFta65WJO/K7+sMoF8V6P0MKfCaHwj/1Va2rp/LKtHd9ttPVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3207,13 +3207,13 @@
         "@babel/plugin-transform-typescript": "^7.25.2",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
         "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.76.9",
-        "babel-plugin-syntax-hermes-parser": "^0.25.1",
+        "@react-native/babel-plugin-codegen": "0.81.1",
+        "babel-plugin-syntax-hermes-parser": "0.29.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
         "@babel/core": "*"
@@ -5139,30 +5139,30 @@
       }
     },
     "node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-2WFYnoWGdmih1I1J5eIqxATOeycOqRwYxAQBu3cUu/rhwInwHUg7k60AFNbuGjSDL8tje5GDrAnxzRLcu2pYcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hermes-parser": "0.25.1"
+        "hermes-parser": "0.29.1"
       }
     },
     "node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-estree": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
-      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-parser": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.25.1"
+        "hermes-estree": "0.29.1"
       }
     },
     "node_modules/babel-plugin-syntax-trailing-function-commas": {

--- a/wifi-handshake-c/package.json
+++ b/wifi-handshake-c/package.json
@@ -36,7 +36,7 @@
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "@react-native/babel-preset": "^0.76.7",
+    "@react-native/babel-preset": "^0.81.1",
     "@react-native/eslint-config": "^0.72.2",
     "@react-native/metro-config": "^0.72.11",
     "@tsconfig/react-native": "^3.0.0",

--- a/wifi-handshake-c/package.json
+++ b/wifi-handshake-c/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.19.3",
+    "@react-native/babel-preset": "^0.81.1",
     "@react-navigation/native": "^6.1.18",
     "@react-navigation/native-stack": "^6.11.0",
     "base64-arraybuffer": "^1.0.2",
@@ -36,7 +37,6 @@
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "@react-native/babel-preset": "^0.81.1",
     "@react-native/eslint-config": "^0.72.2",
     "@react-native/metro-config": "^0.72.11",
     "@tsconfig/react-native": "^3.0.0",

--- a/wifi-handshake-c/src/deepcapture/components/PacketItem.tsx
+++ b/wifi-handshake-c/src/deepcapture/components/PacketItem.tsx
@@ -124,13 +124,11 @@ const PacketItem: React.FC<PacketItemProps> = React.memo(({ packet }) => {
       lines.push(`Protocol: ${protocol}`);
     }
     if (sourceLabel) {
-      lines.push(`Source: ${sourceLabel}`);
+      const hasSrcIp = typeof packet.headers.srcIP === 'string';
+      lines.push(`${hasSrcIp ? 'Source' : 'Source MAC'}: ${sourceLabel}`);
     }
     if (destinationLabel) {
       lines.push(`Destination: ${destinationLabel}`);
-    }
-    if (!protocol && !destinationLabel && sourceLabel) {
-      lines.push(`Source MAC: ${sourceLabel}`);
     }
     if (channel) {
       lines.push(channel);
@@ -154,6 +152,7 @@ const PacketItem: React.FC<PacketItemProps> = React.memo(({ packet }) => {
     packetSize,
     protocol,
     signal,
+    packet.headers.srcIP,
     sourceLabel,
   ]);
 

--- a/wifi-handshake-c/src/services/PacketParserService.ts
+++ b/wifi-handshake-c/src/services/PacketParserService.ts
@@ -340,7 +340,10 @@ export const parsePacket = (
     const payload = new Uint8Array(decode(packet.payload));
     const headerType = String(packet.headers?.type ?? '').toUpperCase();
 
-    let isHandshake = headerType.includes('EAPOL');
+    let isHandshake = Boolean(packet.headers?.isEapol);
+    if (!isHandshake) {
+      isHandshake = headerType.includes('EAPOL');
+    }
 
     if (!isHandshake && payload.length >= 14) {
       isHandshake = payload[12] === 0x88 && payload[13] === 0x8e;

--- a/wifi-handshake-c/src/types/WiFiSniffer.ts
+++ b/wifi-handshake-c/src/types/WiFiSniffer.ts
@@ -172,6 +172,9 @@ export const isWiFiSnifferAvailable = Boolean(nativeModule);
 export interface PacketHeaders {
   type?: string;
   subtype?: string;
+  frameType?: string;
+  frameSubtype?: number | string;
+  frameControl?: number;
   protocol?: string;
   srcIP?: string;
   dstIP?: string;
@@ -179,6 +182,7 @@ export interface PacketHeaders {
   dstPort?: number;
   length?: number;
   payloadLength?: number;
+  packetSize?: number;
   addr1?: string;
   addr2?: string;
   addr3?: string;
@@ -186,7 +190,30 @@ export interface PacketHeaders {
   channel?: number;
   frequency?: number;
   signal?: number;
+  noise?: number;
   radiotapFlags?: number;
+  radiotapPresentFlags?: number;
+  channelFlags?: number;
+  protocolFamily?: string;
+  isEapol?: boolean;
+  eapolVersion?: number;
+  eapolLength?: number;
+  eapolMessage?: number;
+  descriptorType?: number;
+  keyInfo?: number;
+  keyLength?: number;
+  keyDataLength?: number;
+  keyMicPresent?: boolean;
+  keyEncrypted?: boolean;
+  keyAck?: boolean;
+  keyDescriptorVersion?: number;
+  replayCounter?: string;
+  keyNonce?: string;
+  keyIV?: string;
+  keyRSC?: string;
+  keyID?: string;
+  keyMIC?: string;
+  keyData?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- decode radiotap metadata and WPA/EAPOL handshake details in the iOS packet parser so imported PCAPs and live captures surface channel, RSSI, and key descriptors
- harden the packet tunnel provider with IPv4/IPv6 route configuration, protocol family tagging, and stop-reason logging for NetworkExtension troubleshooting
- surface the richer metadata through WifiCaptureImpl, updated TypeScript types, and the deep capture UI while bumping the React Native Babel preset to the latest release

## Testing
- `npx prettier --write .`
- `npm run lint`
- `npm test`
- `npm audit fix --force`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68d37735379c8333a3a54dac7e06d67e

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/ales27pm/prREVIEW/59)
<!-- GitContextEnd -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Richer Wi‑Fi packet metadata: channel, signal/noise, packet size, protocol family, and radiotap details.
  - EAPOL handshake parsing with message type and key info surfaced.
  - Packet list UI enhanced: clearer type/subtype labels, size, noise, and handshake details.

- Improvements
  - More informative VPN disconnect logging with stop reasons.
  - Final capture metrics logged on tunnel stop.
  - IPv4/IPv6 excluded routes added for cleaner tunneling behavior.

- Chores
  - Updated React Native Babel preset dev dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->