### PR TITLE
Add GitHub Actions workflow for iOS ad hoc IPA export

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -5,6 +5,11 @@ on:
     branches: ["main"]
   pull_request:
   workflow_dispatch:
+    inputs:
+      ios-app-path:
+        description: "Relative path to the app directory that contains the ios project folder."
+        required: false
+        default: ""
 
 jobs:
   build-sign-export:
@@ -17,12 +22,12 @@ jobs:
       EXPORT_PATH: ${{ github.workspace }}/build/ios/export
       EXPORT_OPTIONS_PATH: ${{ github.workspace }}/build/ios/exportOptions.plist
       KEYCHAIN_PATH: ${{ runner.temp }}/ios-build.keychain-db
+      IOS_APP_PATH: ${{ github.event.inputs.ios-app-path || vars.IOS_APP_PATH || '' }}
       P12_BASE64: ${{ secrets.P12_BASE64 }}
       P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
       MOBILEPROVISION_BASE64: ${{ secrets.MOBILEPROVISION_BASE64 }}
       KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
       TEAM_ID: ${{ secrets.TEAM_ID }}
-      PROFILE_UUID: ${{ secrets.PROFILE_UUID }}
       BUNDLE_ID_PREFIX: ${{ secrets.BUNDLE_ID_PREFIX }}
       BUNDLE_ID_SUFFIX: ${{ secrets.BUNDLE_ID_SUFFIX }}
     steps:
@@ -54,17 +59,16 @@ jobs:
             exit 1
           fi
           mkdir -p signing
-          python3 - <<'PY'
-import base64
-import os
-from pathlib import Path
-
-cert_data = os.environ["P12_BASE64"].encode()
-profile_data = os.environ["MOBILEPROVISION_BASE64"].encode()
-Path("signing").mkdir(parents=True, exist_ok=True)
-Path("signing/cert.p12").write_bytes(base64.b64decode(cert_data))
-Path("signing/profile.mobileprovision").write_bytes(base64.b64decode(profile_data))
-PY
+          decode_base64() {
+            local data="$1"
+            local output="$2"
+            if printf '%s' "${data}" | base64 --decode > "${output}" 2>/dev/null; then
+              return 0
+            fi
+            printf '%s' "${data}" | base64 -d > "${output}"
+          }
+          decode_base64 "${P12_BASE64}" signing/cert.p12
+          decode_base64 "${MOBILEPROVISION_BASE64}" signing/profile.mobileprovision
           echo "Decoded signing assets into the signing/ directory."
           echo "SHA256 (cert.p12):"
           shasum -a 256 signing/cert.p12
@@ -101,14 +105,25 @@ PY
         run: |
           set -euo pipefail
           PROFILE_DIR="${HOME}/Library/MobileDevice/Provisioning Profiles"
+          PROFILE_PLIST="${RUNNER_TEMP}/profile.plist"
+          security cms -D -i signing/profile.mobileprovision > "${PROFILE_PLIST}"
+          PROFILE_UUID=$(/usr/libexec/PlistBuddy -c 'Print UUID' "${PROFILE_PLIST}")
+          PROFILE_NAME=$(/usr/libexec/PlistBuddy -c 'Print Name' "${PROFILE_PLIST}")
+          if [ -z "${PROFILE_UUID}" ] || [ -z "${PROFILE_NAME}" ]; then
+            echo "::error::Failed to extract provisioning profile metadata." >&2
+            exit 1
+          fi
           PROFILE_INSTALL_PATH="${PROFILE_DIR}/${PROFILE_UUID}.mobileprovision"
           mkdir -p "${PROFILE_DIR}"
           cp signing/profile.mobileprovision "${PROFILE_INSTALL_PATH}"
           echo "Installed provisioning profile at ${PROFILE_INSTALL_PATH}"
+          echo "Provisioning profile name: ${PROFILE_NAME}"
           echo "Provisioning profile UUID: ${PROFILE_UUID}"
           echo "Provisioning profile Team ID: ${TEAM_ID}"
           echo "Installed profile SHA256:"
           shasum -a 256 "${PROFILE_INSTALL_PATH}"
+          echo "PROVISIONING_PROFILE_UUID=${PROFILE_UUID}" >> "${GITHUB_ENV}"
+          echo "PROVISIONING_PROFILE_NAME=${PROFILE_NAME}" >> "${GITHUB_ENV}"
 
       - name: Generate export options plist
         shell: bash
@@ -116,6 +131,10 @@ PY
           set -euo pipefail
           if [ -z "${RESOLVED_BUNDLE_ID:-}" ]; then
             echo "::error::Resolved bundle identifier is unavailable." >&2
+            exit 1
+          fi
+          if [ -z "${PROVISIONING_PROFILE_NAME:-}" ]; then
+            echo "::error::Provisioning profile name is unavailable." >&2
             exit 1
           fi
           mkdir -p "$(dirname "${EXPORT_OPTIONS_PATH}")"
@@ -131,7 +150,7 @@ PY
   <key>provisioningProfiles</key>
   <dict>
     <key>${RESOLVED_BUNDLE_ID}</key>
-    <string>${PROFILE_UUID}</string>
+    <string>${PROVISIONING_PROFILE_NAME}</string>
   </dict>
   <key>teamID</key>
   <string>${TEAM_ID}</string>
@@ -147,18 +166,63 @@ PLIST
 
       - name: Archive app
         shell: bash
-        working-directory: wifi-handshake-c
         run: |
           set -euo pipefail
+          if [ -z "${PROVISIONING_PROFILE_NAME:-}" ] || [ -z "${PROVISIONING_PROFILE_UUID:-}" ]; then
+            echo "::error::Provisioning profile metadata is unavailable." >&2
+            exit 1
+          fi
           mkdir -p "$(dirname "${ARCHIVE_PATH}")"
-          IOS_PROJECT_DIR="ios"
+          APP_DIRECTORY="${IOS_APP_PATH:-}"
+          if [ -n "${APP_DIRECTORY}" ]; then
+            if [ ! -d "${APP_DIRECTORY}" ]; then
+              echo "::error::IOS_APP_PATH (${APP_DIRECTORY}) does not exist." >&2
+              exit 1
+            fi
+            APP_ABSOLUTE_PATH="$(cd "${APP_DIRECTORY}" && pwd)"
+          else
+            IOS_DIR_CANDIDATES=()
+            while IFS= read -r dir; do
+              IOS_DIR_CANDIDATES+=("${dir}")
+            done < <(find "${GITHUB_WORKSPACE}" -maxdepth 3 -type d -name ios -print | sort)
+            if [ "${#IOS_DIR_CANDIDATES[@]}" -eq 0 ]; then
+              echo "::error::Unable to locate an ios directory automatically. Set IOS_APP_PATH to the app root." >&2
+              exit 1
+            elif [ "${#IOS_DIR_CANDIDATES[@]}" -gt 1 ]; then
+              echo "::error::Multiple ios directories found. Set IOS_APP_PATH to choose one." >&2
+              printf ' - %s\n' "${IOS_DIR_CANDIDATES[@]}"
+              exit 1
+            fi
+            APP_ABSOLUTE_PATH="$(dirname "${IOS_DIR_CANDIDATES[0]}")"
+          fi
+          APP_ABSOLUTE_PATH="$(cd "${APP_ABSOLUTE_PATH}" && pwd)"
+          echo "Using app directory: ${APP_ABSOLUTE_PATH}"
+          IOS_PROJECT_DIR="${APP_ABSOLUTE_PATH}/ios"
+          if [ ! -d "${IOS_PROJECT_DIR}" ]; then
+            echo "::error::Resolved iOS project directory ${IOS_PROJECT_DIR} does not exist." >&2
+            exit 1
+          fi
+          cd "${APP_ABSOLUTE_PATH}"
           declare -a BUILD_DEST_ARG
-          if compgen -G "${IOS_PROJECT_DIR}/*.xcworkspace" > /dev/null; then
-            WORKSPACE_PATH=$(ls "${IOS_PROJECT_DIR}"/*.xcworkspace | head -n 1)
+          WORKSPACE_COUNT=$(find "${IOS_PROJECT_DIR}" -maxdepth 1 -name "*.xcworkspace" | wc -l | tr -d '[:space:]')
+          PROJECT_COUNT=$(find "${IOS_PROJECT_DIR}" -maxdepth 1 -name "*.xcodeproj" | wc -l | tr -d '[:space:]')
+
+          if [ "${WORKSPACE_COUNT}" -gt 0 ]; then
+            if [ "${WORKSPACE_COUNT}" -gt 1 ]; then
+              echo "::error::Multiple Xcode workspaces found under ${IOS_PROJECT_DIR}. Please specify which to use." >&2
+              find "${IOS_PROJECT_DIR}" -maxdepth 1 -name "*.xcworkspace"
+              exit 1
+            fi
+            WORKSPACE_PATH=$(find "${IOS_PROJECT_DIR}" -maxdepth 1 -name "*.xcworkspace" -print | sort | head -n 1)
             BUILD_DEST_ARG=(-workspace "${WORKSPACE_PATH}")
             echo "Detected workspace: ${WORKSPACE_PATH}"
-          elif compgen -G "${IOS_PROJECT_DIR}/*.xcodeproj" > /dev/null; then
-            PROJECT_PATH=$(ls "${IOS_PROJECT_DIR}"/*.xcodeproj | head -n 1)
+          elif [ "${PROJECT_COUNT}" -gt 0 ]; then
+            if [ "${PROJECT_COUNT}" -gt 1 ]; then
+              echo "::error::Multiple Xcode projects found under ${IOS_PROJECT_DIR}. Please specify which to use." >&2
+              find "${IOS_PROJECT_DIR}" -maxdepth 1 -name "*.xcodeproj"
+              exit 1
+            fi
+            PROJECT_PATH=$(find "${IOS_PROJECT_DIR}" -maxdepth 1 -name "*.xcodeproj" -print | sort | head -n 1)
             BUILD_DEST_ARG=(-project "${PROJECT_PATH}")
             echo "Detected project: ${PROJECT_PATH}"
           else
@@ -174,7 +238,8 @@ PLIST
             CODE_SIGN_STYLE=Manual \
             DEVELOPMENT_TEAM="${TEAM_ID}" \
             PRODUCT_BUNDLE_IDENTIFIER="${RESOLVED_BUNDLE_ID}" \
-            PROVISIONING_PROFILE_SPECIFIER="${PROFILE_UUID}" \
+            PROVISIONING_PROFILE_SPECIFIER="${PROVISIONING_PROFILE_NAME}" \
+            PROVISIONING_PROFILE="${PROVISIONING_PROFILE_UUID}" \
             OTHER_CODE_SIGN_FLAGS="--keychain ${KEYCHAIN_PATH}" \
             archive
 
@@ -187,11 +252,11 @@ PLIST
           set -euo pipefail
           mkdir -p "${EXPORT_PATH}"
           echo "Exporting IPA to ${EXPORT_PATH} using ${EXPORT_OPTIONS_PATH}"
-          env OTHER_CODE_SIGN_FLAGS="--keychain ${KEYCHAIN_PATH}" \
-            xcodebuild -exportArchive \
+          xcodebuild -exportArchive \
             -archivePath "${ARCHIVE_PATH}" \
             -exportPath "${EXPORT_PATH}" \
-            -exportOptionsPlist "${EXPORT_OPTIONS_PATH}"
+            -exportOptionsPlist "${EXPORT_OPTIONS_PATH}" \
+            OTHER_CODE_SIGN_FLAGS="--keychain ${KEYCHAIN_PATH}"
           echo "Export complete. Generated files:"
           find "${EXPORT_PATH}" -maxdepth 1 -type f -print
 
@@ -201,6 +266,13 @@ PLIST
           name: ios-ad-hoc-build
           path: ${{ env.EXPORT_PATH }}
           if-no-files-found: error
+
+      - name: Upload dSYM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ad-hoc-dsyms
+          path: ${{ env.ARCHIVE_PATH }}/dSYMs
+          if-no-files-found: warn
 
       - name: Cleanup keychain
         if: always()

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -34,6 +34,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Mask sensitive values
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "${TEAM_ID:-}" ]; then
+            echo "::add-mask::${TEAM_ID}"
+          fi
+
       - name: Resolve bundle identifier
         shell: bash
         run: |
@@ -129,7 +137,7 @@ jobs:
           echo "Installed provisioning profile at ${PROFILE_INSTALL_PATH}"
           echo "Provisioning profile name: ${PROFILE_NAME}"
           echo "Provisioning profile UUID: ${PROFILE_UUID}"
-          echo "Provisioning profile Team ID: ${TEAM_ID}"
+          echo "Provisioning profile Team ID is configured."
           echo "Installed profile SHA256:"
           shasum -a 256 "${PROFILE_INSTALL_PATH}"
           echo "PROVISIONING_PROFILE_UUID=${PROFILE_UUID}" >> "${GITHUB_ENV}"
@@ -157,7 +165,6 @@ jobs:
           /usr/libexec/PlistBuddy -c 'Add :stripSwiftSymbols bool true' "${EXPORT_OPTIONS_PATH}"
           /usr/libexec/PlistBuddy -c 'Add :compileBitcode bool false' "${EXPORT_OPTIONS_PATH}"
           echo "exportOptions.plist created at ${EXPORT_OPTIONS_PATH}"
-          cat "${EXPORT_OPTIONS_PATH}"
 
       - name: Archive app
         shell: bash

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -138,29 +138,29 @@ jobs:
             exit 1
           fi
           mkdir -p "$(dirname "${EXPORT_OPTIONS_PATH}")"
-          cat <<PLIST > "${EXPORT_OPTIONS_PATH}"
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>method</key>
-  <string>ad-hoc</string>
-  <key>signingStyle</key>
-  <string>manual</string>
-  <key>provisioningProfiles</key>
-  <dict>
-    <key>${RESOLVED_BUNDLE_ID}</key>
-    <string>${PROVISIONING_PROFILE_NAME}</string>
-  </dict>
-  <key>teamID</key>
-  <string>${TEAM_ID}</string>
-  <key>stripSwiftSymbols</key>
-  <true/>
-  <key>compileBitcode</key>
-  <false/>
-</dict>
-</plist>
-PLIST
+          cat <<PLIST | sed 's/^          //' > "${EXPORT_OPTIONS_PATH}"
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>ad-hoc</string>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>${RESOLVED_BUNDLE_ID}</key>
+              <string>${PROVISIONING_PROFILE_NAME}</string>
+            </dict>
+            <key>teamID</key>
+            <string>${TEAM_ID}</string>
+            <key>stripSwiftSymbols</key>
+            <true/>
+            <key>compileBitcode</key>
+            <false/>
+          </dict>
+          </plist>
+          PLIST
           echo "exportOptions.plist created at ${EXPORT_OPTIONS_PATH}"
           cat "${EXPORT_OPTIONS_PATH}"
 

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,0 +1,217 @@
+name: iOS Ad Hoc Build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-sign-export:
+    name: Build, Sign, and Export Ad Hoc IPA
+    runs-on: macos-latest
+    env:
+      SCHEME: YourAppScheme
+      CONFIGURATION: Release
+      ARCHIVE_PATH: ${{ github.workspace }}/build/ios/YourAppScheme.xcarchive
+      EXPORT_PATH: ${{ github.workspace }}/build/ios/export
+      EXPORT_OPTIONS_PATH: ${{ github.workspace }}/build/ios/exportOptions.plist
+      KEYCHAIN_PATH: ${{ runner.temp }}/ios-build.keychain-db
+      P12_BASE64: ${{ secrets.P12_BASE64 }}
+      P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+      MOBILEPROVISION_BASE64: ${{ secrets.MOBILEPROVISION_BASE64 }}
+      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+      TEAM_ID: ${{ secrets.TEAM_ID }}
+      PROFILE_UUID: ${{ secrets.PROFILE_UUID }}
+      BUNDLE_ID_PREFIX: ${{ secrets.BUNDLE_ID_PREFIX }}
+      BUNDLE_ID_SUFFIX: ${{ secrets.BUNDLE_ID_SUFFIX }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve bundle identifier
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${BUNDLE_ID_PREFIX:-}" ] || [ -z "${BUNDLE_ID_SUFFIX:-}" ]; then
+            echo "::error::BUNDLE_ID_PREFIX and BUNDLE_ID_SUFFIX secrets must be provided." >&2
+            exit 1
+          fi
+          RESOLVED_BUNDLE_ID="${BUNDLE_ID_PREFIX}.${BUNDLE_ID_SUFFIX}"
+          echo "RESOLVED_BUNDLE_ID=${RESOLVED_BUNDLE_ID}" >> "${GITHUB_ENV}"
+          echo "Using bundle identifier: ${RESOLVED_BUNDLE_ID}"
+
+      - name: Decode signing assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${P12_BASE64:-}" ]; then
+            echo "::error::P12_BASE64 secret is required." >&2
+            exit 1
+          fi
+          if [ -z "${MOBILEPROVISION_BASE64:-}" ]; then
+            echo "::error::MOBILEPROVISION_BASE64 secret is required." >&2
+            exit 1
+          fi
+          mkdir -p signing
+          python3 - <<'PY'
+import base64
+import os
+from pathlib import Path
+
+cert_data = os.environ["P12_BASE64"].encode()
+profile_data = os.environ["MOBILEPROVISION_BASE64"].encode()
+Path("signing").mkdir(parents=True, exist_ok=True)
+Path("signing/cert.p12").write_bytes(base64.b64decode(cert_data))
+Path("signing/profile.mobileprovision").write_bytes(base64.b64decode(profile_data))
+PY
+          echo "Decoded signing assets into the signing/ directory."
+          echo "SHA256 (cert.p12):"
+          shasum -a 256 signing/cert.p12
+          echo "SHA256 (profile.mobileprovision):"
+          shasum -a 256 signing/profile.mobileprovision
+
+      - name: Configure temporary keychain
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${KEYCHAIN_PASSWORD:-}" ]; then
+            echo "::error::KEYCHAIN_PASSWORD secret is required." >&2
+            exit 1
+          fi
+          if [ -z "${P12_PASSWORD:-}" ]; then
+            echo "::error::P12_PASSWORD secret is required." >&2
+            exit 1
+          fi
+          ORIGINAL_KEYCHAINS_FILE="${RUNNER_TEMP}/original-keychains.list"
+          security list-keychains -d user > "${ORIGINAL_KEYCHAINS_FILE}"
+          echo "ORIGINAL_KEYCHAINS_FILE=${ORIGINAL_KEYCHAINS_FILE}" >> "${GITHUB_ENV}"
+
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          security set-keychain-settings -lut 21600 "${KEYCHAIN_PATH}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          security list-keychains -d user -s "${KEYCHAIN_PATH}" $(tr -d '"' < "${ORIGINAL_KEYCHAINS_FILE}")
+          security default-keychain -d user -s "${KEYCHAIN_PATH}"
+          security import signing/cert.p12 -k "${KEYCHAIN_PATH}" -P "${P12_PASSWORD}" -T /usr/bin/codesign -T /usr/bin/security -A
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          echo "Temporary keychain ready at ${KEYCHAIN_PATH}"
+
+      - name: Install provisioning profile
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROFILE_DIR="${HOME}/Library/MobileDevice/Provisioning Profiles"
+          PROFILE_INSTALL_PATH="${PROFILE_DIR}/${PROFILE_UUID}.mobileprovision"
+          mkdir -p "${PROFILE_DIR}"
+          cp signing/profile.mobileprovision "${PROFILE_INSTALL_PATH}"
+          echo "Installed provisioning profile at ${PROFILE_INSTALL_PATH}"
+          echo "Provisioning profile UUID: ${PROFILE_UUID}"
+          echo "Provisioning profile Team ID: ${TEAM_ID}"
+          echo "Installed profile SHA256:"
+          shasum -a 256 "${PROFILE_INSTALL_PATH}"
+
+      - name: Generate export options plist
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${RESOLVED_BUNDLE_ID:-}" ]; then
+            echo "::error::Resolved bundle identifier is unavailable." >&2
+            exit 1
+          fi
+          mkdir -p "$(dirname "${EXPORT_OPTIONS_PATH}")"
+          cat <<PLIST > "${EXPORT_OPTIONS_PATH}"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>ad-hoc</string>
+  <key>signingStyle</key>
+  <string>manual</string>
+  <key>provisioningProfiles</key>
+  <dict>
+    <key>${RESOLVED_BUNDLE_ID}</key>
+    <string>${PROFILE_UUID}</string>
+  </dict>
+  <key>teamID</key>
+  <string>${TEAM_ID}</string>
+  <key>stripSwiftSymbols</key>
+  <true/>
+  <key>compileBitcode</key>
+  <false/>
+</dict>
+</plist>
+PLIST
+          echo "exportOptions.plist created at ${EXPORT_OPTIONS_PATH}"
+          cat "${EXPORT_OPTIONS_PATH}"
+
+      - name: Archive app
+        shell: bash
+        working-directory: wifi-handshake-c
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "${ARCHIVE_PATH}")"
+          IOS_PROJECT_DIR="ios"
+          declare -a BUILD_DEST_ARG
+          if compgen -G "${IOS_PROJECT_DIR}/*.xcworkspace" > /dev/null; then
+            WORKSPACE_PATH=$(ls "${IOS_PROJECT_DIR}"/*.xcworkspace | head -n 1)
+            BUILD_DEST_ARG=(-workspace "${WORKSPACE_PATH}")
+            echo "Detected workspace: ${WORKSPACE_PATH}"
+          elif compgen -G "${IOS_PROJECT_DIR}/*.xcodeproj" > /dev/null; then
+            PROJECT_PATH=$(ls "${IOS_PROJECT_DIR}"/*.xcodeproj | head -n 1)
+            BUILD_DEST_ARG=(-project "${PROJECT_PATH}")
+            echo "Detected project: ${PROJECT_PATH}"
+          else
+            echo "::error::No Xcode workspace or project found under ${IOS_PROJECT_DIR}" >&2
+            exit 1
+          fi
+
+          echo "Starting archive build for scheme ${SCHEME} (configuration: ${CONFIGURATION})"
+          xcodebuild "${BUILD_DEST_ARG[@]}" \
+            -scheme "${SCHEME}" \
+            -configuration "${CONFIGURATION}" \
+            -archivePath "${ARCHIVE_PATH}" \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM="${TEAM_ID}" \
+            PRODUCT_BUNDLE_IDENTIFIER="${RESOLVED_BUNDLE_ID}" \
+            PROVISIONING_PROFILE_SPECIFIER="${PROFILE_UUID}" \
+            OTHER_CODE_SIGN_FLAGS="--keychain ${KEYCHAIN_PATH}" \
+            archive
+
+          echo "Archive completed at ${ARCHIVE_PATH}"
+          ls "${ARCHIVE_PATH}"
+
+      - name: Export IPA
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${EXPORT_PATH}"
+          echo "Exporting IPA to ${EXPORT_PATH} using ${EXPORT_OPTIONS_PATH}"
+          env OTHER_CODE_SIGN_FLAGS="--keychain ${KEYCHAIN_PATH}" \
+            xcodebuild -exportArchive \
+            -archivePath "${ARCHIVE_PATH}" \
+            -exportPath "${EXPORT_PATH}" \
+            -exportOptionsPlist "${EXPORT_OPTIONS_PATH}"
+          echo "Export complete. Generated files:"
+          find "${EXPORT_PATH}" -maxdepth 1 -type f -print
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ad-hoc-build
+          path: ${{ env.EXPORT_PATH }}
+          if-no-files-found: error
+
+      - name: Cleanup keychain
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "${ORIGINAL_KEYCHAINS_FILE:-}" ] && [ -f "${ORIGINAL_KEYCHAINS_FILE}" ]; then
+            security list-keychains -d user -s $(tr -d '"' < "${ORIGINAL_KEYCHAINS_FILE}")
+            rm -f "${ORIGINAL_KEYCHAINS_FILE}" || true
+          fi
+          security default-keychain -d user -s login.keychain-db || \
+            security default-keychain -d user -s login.keychain || true
+          security delete-keychain "${KEYCHAIN_PATH}" || true
+          echo "Temporary keychain cleaned up."

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -21,7 +21,6 @@ jobs:
       ARCHIVE_PATH: ${{ github.workspace }}/build/ios/YourAppScheme.xcarchive
       EXPORT_PATH: ${{ github.workspace }}/build/ios/export
       EXPORT_OPTIONS_PATH: ${{ github.workspace }}/build/ios/exportOptions.plist
-      KEYCHAIN_PATH: ${{ runner.temp }}/ios-build.keychain-db
       IOS_APP_PATH: ${{ github.event.inputs.ios-app-path || vars.IOS_APP_PATH || '' }}
       P12_BASE64: ${{ secrets.P12_BASE64 }}
       P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
@@ -88,8 +87,10 @@ jobs:
             exit 1
           fi
           ORIGINAL_KEYCHAINS_FILE="${RUNNER_TEMP}/original-keychains.list"
+          KEYCHAIN_PATH="${RUNNER_TEMP}/ios-build.keychain-db"
           security list-keychains -d user > "${ORIGINAL_KEYCHAINS_FILE}"
           echo "ORIGINAL_KEYCHAINS_FILE=${ORIGINAL_KEYCHAINS_FILE}" >> "${GITHUB_ENV}"
+          echo "KEYCHAIN_PATH=${KEYCHAIN_PATH}" >> "${GITHUB_ENV}"
 
           security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
           security set-keychain-settings -lut 21600 "${KEYCHAIN_PATH}"
@@ -172,6 +173,10 @@ jobs:
             echo "::error::Provisioning profile metadata is unavailable." >&2
             exit 1
           fi
+          if [ -z "${KEYCHAIN_PATH:-}" ]; then
+            echo "::error::Keychain path is unavailable." >&2
+            exit 1
+          fi
           mkdir -p "$(dirname "${ARCHIVE_PATH}")"
           APP_DIRECTORY="${IOS_APP_PATH:-}"
           if [ -n "${APP_DIRECTORY}" ]; then
@@ -251,6 +256,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${EXPORT_PATH}"
+          if [ -z "${KEYCHAIN_PATH:-}" ]; then
+            echo "::error::Keychain path is unavailable." >&2
+            exit 1
+          fi
           echo "Exporting IPA to ${EXPORT_PATH} using ${EXPORT_OPTIONS_PATH}"
           xcodebuild -exportArchive \
             -archivePath "${ARCHIVE_PATH}" \
@@ -285,5 +294,7 @@ jobs:
           fi
           security default-keychain -d user -s login.keychain-db || \
             security default-keychain -d user -s login.keychain || true
-          security delete-keychain "${KEYCHAIN_PATH}" || true
+          if [ -n "${KEYCHAIN_PATH:-}" ]; then
+            security delete-keychain "${KEYCHAIN_PATH}" || true
+          fi
           echo "Temporary keychain cleaned up."

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -21,6 +21,7 @@ jobs:
       ARCHIVE_PATH: ${{ github.workspace }}/build/ios/YourAppScheme.xcarchive
       EXPORT_PATH: ${{ github.workspace }}/build/ios/export
       EXPORT_OPTIONS_PATH: ${{ github.workspace }}/build/ios/exportOptions.plist
+      KEYCHAIN_PATH: ${{ github.workspace }}/tmp/ios-build.keychain-db
       IOS_APP_PATH: ${{ github.event.inputs.ios-app-path || vars.IOS_APP_PATH || '' }}
       P12_BASE64: ${{ secrets.P12_BASE64 }}
       P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
@@ -61,10 +62,14 @@ jobs:
           decode_base64() {
             local data="$1"
             local output="$2"
-            if printf '%s' "${data}" | base64 --decode > "${output}" 2>/dev/null; then
+            # Try BSD (macOS) flag first, then GNU short, then GNU long flag.
+            if printf '%s' "${data}" | base64 -D > "${output}" 2>/dev/null; then
               return 0
             fi
-            printf '%s' "${data}" | base64 -d > "${output}"
+            if printf '%s' "${data}" | base64 -d > "${output}" 2>/dev/null; then
+              return 0
+            fi
+            printf '%s' "${data}" | base64 --decode > "${output}"
           }
           decode_base64 "${P12_BASE64}" signing/cert.p12
           decode_base64 "${MOBILEPROVISION_BASE64}" signing/profile.mobileprovision
@@ -87,11 +92,15 @@ jobs:
             exit 1
           fi
           ORIGINAL_KEYCHAINS_FILE="${RUNNER_TEMP}/original-keychains.list"
-          KEYCHAIN_PATH="${RUNNER_TEMP}/ios-build.keychain-db"
+          if [ -z "${KEYCHAIN_PATH:-}" ]; then
+            echo "::error::KEYCHAIN_PATH environment variable is not set." >&2
+            exit 1
+          fi
           security list-keychains -d user > "${ORIGINAL_KEYCHAINS_FILE}"
           echo "ORIGINAL_KEYCHAINS_FILE=${ORIGINAL_KEYCHAINS_FILE}" >> "${GITHUB_ENV}"
           echo "KEYCHAIN_PATH=${KEYCHAIN_PATH}" >> "${GITHUB_ENV}"
 
+          mkdir -p "$(dirname "${KEYCHAIN_PATH}")"
           security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
           security set-keychain-settings -lut 21600 "${KEYCHAIN_PATH}"
           security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
@@ -139,29 +148,14 @@ jobs:
             exit 1
           fi
           mkdir -p "$(dirname "${EXPORT_OPTIONS_PATH}")"
-          cat <<PLIST | sed 's/^          //' > "${EXPORT_OPTIONS_PATH}"
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-            <key>method</key>
-            <string>ad-hoc</string>
-            <key>signingStyle</key>
-            <string>manual</string>
-            <key>provisioningProfiles</key>
-            <dict>
-              <key>${RESOLVED_BUNDLE_ID}</key>
-              <string>${PROVISIONING_PROFILE_NAME}</string>
-            </dict>
-            <key>teamID</key>
-            <string>${TEAM_ID}</string>
-            <key>stripSwiftSymbols</key>
-            <true/>
-            <key>compileBitcode</key>
-            <false/>
-          </dict>
-          </plist>
-          PLIST
+          plutil -create xml1 "${EXPORT_OPTIONS_PATH}"
+          /usr/libexec/PlistBuddy -c 'Add :method string ad-hoc' "${EXPORT_OPTIONS_PATH}"
+          /usr/libexec/PlistBuddy -c 'Add :signingStyle string manual' "${EXPORT_OPTIONS_PATH}"
+          /usr/libexec/PlistBuddy -c 'Add :provisioningProfiles dict' "${EXPORT_OPTIONS_PATH}"
+          /usr/libexec/PlistBuddy -c "Add :provisioningProfiles:${RESOLVED_BUNDLE_ID} string ${PROVISIONING_PROFILE_NAME}" "${EXPORT_OPTIONS_PATH}"
+          /usr/libexec/PlistBuddy -c "Add :teamID string ${TEAM_ID}" "${EXPORT_OPTIONS_PATH}"
+          /usr/libexec/PlistBuddy -c 'Add :stripSwiftSymbols bool true' "${EXPORT_OPTIONS_PATH}"
+          /usr/libexec/PlistBuddy -c 'Add :compileBitcode bool false' "${EXPORT_OPTIONS_PATH}"
           echo "exportOptions.plist created at ${EXPORT_OPTIONS_PATH}"
           cat "${EXPORT_OPTIONS_PATH}"
 


### PR DESCRIPTION
## Summary
- add an iOS build workflow that decodes signing assets, configures a temporary keychain, and installs the ad hoc provisioning profile
- archive the app with manual signing using repository secrets and export an ad hoc IPA with the required exportOptions plist
- publish the exported IPA as a workflow artifact and clean up the temporary keychain for reproducible CI builds

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d39208cbc48333bcd27621795c4f3e

## Summary by Sourcery

Implement a CI workflow that automates decoding signing credentials, setting up keychains, archiving the app, exporting an ad-hoc IPA, and publishing it as an artifact in GitHub Actions

CI:
- Add GitHub Actions workflow to build, sign, and export an ad-hoc iOS IPA on macos-latest
- Decode base64 signing assets, configure a temporary keychain, and install the ad-hoc provisioning profile
- Generate ad-hoc exportOptions plist and archive the app with manual signing using repository secrets
- Upload the exported IPA as a workflow artifact and clean up the temporary keychain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an iOS Ad Hoc Build workflow for GitHub Actions.
  * Triggers on pushes, pull requests, and manual runs with configurable app path.
  * Automates secure code signing, provisioning profile handling, and temporary keychain management.
  * Archives and exports an IPA, uploading app and dSYM artifacts for download.
  * Auto-detects project/workspace when possible, validates configuration, and provides clear logs and outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->